### PR TITLE
Add WebAssembly support with platform-specific abstractions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,6 @@ gpu-utils = { path = "gpu-utils" }
 # async runtime, utilities
 tokio = { version = "1", features = [
     "rt",
-    "rt-multi-thread",
     "macros",
     "sync",
     "parking_lot",
@@ -49,7 +48,7 @@ accesskit = "0.21"
 accesskit_winit = { version = "0.29", features = ["tokio"] }
 
 # graphics
-wgpu = { version = "27.0.1", features = ["noop"] }
+wgpu = { version = "27.0.1", features = ["noop", "webgpu"] }
 bytemuck = { version = "1", features = ["derive"] }
 vello = { git = "https://github.com/linebender/vello.git", branch = "main" }
 

--- a/gpu-utils/Cargo.toml
+++ b/gpu-utils/Cargo.toml
@@ -9,7 +9,7 @@ wgpu = { workspace = true }
 log = { workspace = true }
 guillotiere = "0.6"                              # texture atlas library # internal use only
 parking_lot = { workspace = true }
-uuid = { version = "1.17.0", features = ["v4"] } # internal use only
+uuid = { version = "1.17.0", features = ["v4", "js"] }
 dashmap = { workspace = true }
 fxhash = { workspace = true }
 thiserror = { workspace = true }

--- a/gpu-utils/src/gpu.rs
+++ b/gpu-utils/src/gpu.rs
@@ -19,9 +19,19 @@ pub struct GpuDescriptor {
 impl Default for GpuDescriptor {
     fn default() -> Self {
         Self {
+            #[cfg(not(target_arch = "wasm32"))]
             backends: wgpu::Backends::PRIMARY,
+            #[cfg(target_arch = "wasm32")]
+            backends: wgpu::Backends::BROWSER_WEBGPU,
+
             power_preference: wgpu::PowerPreference::LowPower,
-            required_features: wgpu::Features::PUSH_CONSTANTS | wgpu::Features::VERTEX_WRITABLE_STORAGE,
+
+            #[cfg(not(target_arch = "wasm32"))]
+            required_features: wgpu::Features::PUSH_CONSTANTS
+                | wgpu::Features::VERTEX_WRITABLE_STORAGE,
+            #[cfg(target_arch = "wasm32")]
+            required_features: wgpu::Features::empty(),
+
             required_limits: None,
             preferred_surface_format: wgpu::TextureFormat::Bgra8UnormSrgb,
         }
@@ -165,6 +175,7 @@ impl Gpu {
     /// Using `spawn_blocking` at the call site also acts as the single-recovery
     /// guard: the caller is responsible for not invoking this concurrently
     /// (e.g. by checking a flag before spawning, or via an outer `Mutex`).
+    #[cfg(not(target_arch = "wasm32"))]
     pub fn recover(&self) -> Result<(wgpu::Device, wgpu::Queue), GpuError> {
         debug!("Gpu::recover: requesting new device");
         let mut device_queue = self.device_queue.write();

--- a/gpu-utils/src/texture_atlas/atlas_simple/atlas.rs
+++ b/gpu-utils/src/texture_atlas/atlas_simple/atlas.rs
@@ -302,9 +302,10 @@ impl AtlasRegion {
                 allocation_height,
             );
             atlas.viewport_clear.render(
-                &atlas.device(),
+                &atlas.queue(),
                 &mut clear_pass,
                 atlas.format(),
+                &atlas.device(),
                 [0.0, 0.0, 0.0, 0.0],
             );
         }
@@ -477,6 +478,7 @@ pub struct TextureAtlas {
     state: Mutex<TextureAtlasState>,
     resources: RwLock<TextureAtlasResources>,
     device: RwLock<wgpu::Device>,
+    queue: RwLock<wgpu::Queue>,
     viewport_clear: ViewportClear,
     margin: u32,
     weak_self: Weak<Self>,
@@ -502,6 +504,7 @@ impl TextureAtlas {
 
     pub fn new(
         device: &wgpu::Device,
+        queue: &wgpu::Queue,
         size: wgpu::Extent3d,
         format: wgpu::TextureFormat,
         margin: u32,
@@ -533,6 +536,7 @@ impl TextureAtlas {
             state: Mutex::new(state),
             resources: RwLock::new(resources),
             device: RwLock::new(device.clone()),
+            queue: RwLock::new(queue.clone()),
             viewport_clear: ViewportClear::default(),
             margin,
             weak_self: weak_self.clone(),
@@ -541,7 +545,7 @@ impl TextureAtlas {
 }
 
 impl DeviceLossRecoverable for TextureAtlas {
-    fn recover(&self, device: &wgpu::Device, _: &wgpu::Queue) {
+    fn recover(&self, device: &wgpu::Device, queue: &wgpu::Queue) {
         let format = self.format;
         let size = self.size();
         let id = self.id;
@@ -574,6 +578,7 @@ impl DeviceLossRecoverable for TextureAtlas {
         *resources_lock = resources;
 
         *self.device.write() = device.clone();
+        *self.queue.write() = queue.clone();
         self.viewport_clear.reset();
 
         trace!(
@@ -593,6 +598,10 @@ impl TextureAtlas {
 
     fn device(&self) -> wgpu::Device {
         self.device.read().clone()
+    }
+
+    fn queue(&self) -> wgpu::Queue {
+        self.queue.read().clone()
     }
 
     pub fn margin(&self) -> u32 {
@@ -954,7 +963,7 @@ mod tests {
         margin: u32,
     ) -> (wgpu::Device, wgpu::Queue, Arc<TextureAtlas>) {
         let (_, _, device, queue) = crate::wgpu_utils::noop_wgpu().await;
-        let atlas = TextureAtlas::new(&device, size, format, margin);
+        let atlas = TextureAtlas::new(&device, &queue, size, format, margin);
         (device, queue, atlas)
     }
 

--- a/gpu-utils/src/texture_atlas/atlas_simple/atlas/viewport_clear.rs
+++ b/gpu-utils/src/texture_atlas/atlas_simple/atlas/viewport_clear.rs
@@ -3,152 +3,21 @@ use std::collections::HashMap;
 use parking_lot::Mutex;
 use wgpu::PipelineCompilationOptions;
 
-#[derive(Default)]
-pub(super) struct ViewportClear {
-    inner: Mutex<Option<ViewportClearInner>>,
-}
-
-struct ViewportClearInner {
-    pipeline_layout: wgpu::PipelineLayout,
-    shader: wgpu::ShaderModule,
-    pipelines: HashMap<wgpu::TextureFormat, wgpu::RenderPipeline>,
-    #[cfg(target_arch = "wasm32")]
-    uniform_buffer: wgpu::Buffer,
-    #[cfg(target_arch = "wasm32")]
-    bind_group_layout: wgpu::BindGroupLayout,
-    #[cfg(target_arch = "wasm32")]
-    bind_group: wgpu::BindGroup,
-}
-
 #[repr(C)]
-#[derive(Copy, Clone, Debug, bytemuck::Pod, bytemuck::Zeroable)]
+#[derive(Copy, Clone, bytemuck::Pod, bytemuck::Zeroable)]
 struct PushConstant {
     color: [f32; 4],
 }
 
 const PUSH_CONSTANT_SIZE: u32 = std::mem::size_of::<PushConstant>() as u32;
 
-impl ViewportClearInner {
-    fn new(device: &wgpu::Device) -> Self {
-        #[cfg(not(target_arch = "wasm32"))]
-        let (pipeline_layout, bgl_opt) = {
-            let layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
-                label: Some("atlas_viewport_clear_pipeline_layout"),
-                bind_group_layouts: &[],
-                push_constant_ranges: &[wgpu::PushConstantRange {
-                    stages: wgpu::ShaderStages::FRAGMENT,
-                    range: 0..PUSH_CONSTANT_SIZE,
-                }],
-            });
-            (layout, ())
-        };
+// ---------------------------------------------------------------------------
+// Public wrapper — no cfg
+// ---------------------------------------------------------------------------
 
-        #[cfg(target_arch = "wasm32")]
-        let (pipeline_layout, bgl_opt) = {
-            let bgl = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
-                label: Some("atlas_viewport_clear_bgl"),
-                entries: &[wgpu::BindGroupLayoutEntry {
-                    binding: 0,
-                    visibility: wgpu::ShaderStages::FRAGMENT,
-                    ty: wgpu::BindingType::Buffer {
-                        ty: wgpu::BufferBindingType::Uniform,
-                        has_dynamic_offset: false,
-                        min_binding_size: None,
-                    },
-                    count: None,
-                }],
-            });
-            let layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
-                label: Some("atlas_viewport_clear_pipeline_layout"),
-                bind_group_layouts: &[&bgl],
-                push_constant_ranges: &[],
-            });
-            (layout, bgl)
-        };
-
-        #[cfg(not(target_arch = "wasm32"))]
-        let src = include_str!("viewport_clear.wgsl");
-        #[cfg(target_arch = "wasm32")]
-        let src = include_str!("viewport_clear_web.wgsl");
-
-        let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
-            label: Some("atlas_viewport_clear_shader"),
-            source: wgpu::ShaderSource::Wgsl(src.into()),
-        });
-
-        #[cfg(target_arch = "wasm32")]
-        let uniform_buffer = device.create_buffer(&wgpu::BufferDescriptor {
-            label: Some("atlas_viewport_clear_uniform"),
-            size: 16,
-            usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
-            mapped_at_creation: false,
-        });
-
-        #[cfg(target_arch = "wasm32")]
-        let bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
-            label: Some("atlas_viewport_clear_bind_group"),
-            layout: &bgl_opt,
-            entries: &[wgpu::BindGroupEntry {
-                binding: 0,
-                resource: uniform_buffer.as_entire_binding(),
-            }],
-        });
-
-        // suppress unused warning on native
-        let _ = &bgl_opt;
-
-        ViewportClearInner {
-            pipeline_layout,
-            shader,
-            pipelines: HashMap::new(),
-            #[cfg(target_arch = "wasm32")]
-            bind_group_layout: bgl_opt,
-            #[cfg(target_arch = "wasm32")]
-            uniform_buffer,
-            #[cfg(target_arch = "wasm32")]
-            bind_group,
-        }
-    }
-
-    fn pipeline(
-        &mut self,
-        device: &wgpu::Device,
-        format: wgpu::TextureFormat,
-    ) -> &wgpu::RenderPipeline {
-        let shader = &self.shader;
-        let pipeline_layout = &self.pipeline_layout;
-        self.pipelines.entry(format).or_insert_with(|| {
-            device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
-                label: Some("atlas_viewport_clear_pipeline"),
-                layout: Some(pipeline_layout),
-                vertex: wgpu::VertexState {
-                    module: shader,
-                    entry_point: Some("vs_main"),
-                    buffers: &[],
-                    compilation_options: PipelineCompilationOptions::default(),
-                },
-                fragment: Some(wgpu::FragmentState {
-                    module: shader,
-                    entry_point: Some("fs_main"),
-                    targets: &[Some(wgpu::ColorTargetState {
-                        format,
-                        blend: Some(wgpu::BlendState::REPLACE),
-                        write_mask: wgpu::ColorWrites::ALL,
-                    })],
-                    compilation_options: PipelineCompilationOptions::default(),
-                }),
-                primitive: wgpu::PrimitiveState {
-                    topology: wgpu::PrimitiveTopology::TriangleStrip,
-                    cull_mode: None,
-                    ..Default::default()
-                },
-                depth_stencil: None,
-                multisample: wgpu::MultisampleState::default(),
-                multiview: None,
-                cache: None,
-            })
-        })
-    }
+#[derive(Default)]
+pub(super) struct ViewportClear {
+    inner: Mutex<Option<ViewportClearInner>>,
 }
 
 impl ViewportClear {
@@ -162,30 +31,245 @@ impl ViewportClear {
     ) {
         let mut guard = self.inner.lock();
         let inner = guard.get_or_insert_with(|| ViewportClearInner::new(device));
-        let pipeline = inner.pipeline(device, target_format);
-
-        render_pass.set_pipeline(pipeline);
-
-        let constants = PushConstant { color };
-        #[cfg(not(target_arch = "wasm32"))]
-        render_pass.set_push_constants(
-            wgpu::ShaderStages::FRAGMENT,
-            0,
-            bytemuck::bytes_of(&constants),
-        );
-        #[cfg(target_arch = "wasm32")]
-        {
-            queue.write_buffer(&inner.uniform_buffer, 0, bytemuck::bytes_of(&constants));
-            render_pass.set_bind_group(0, &inner.bind_group, &[]);
-        }
-
-        // suppress unused warning on native
-        let _ = queue;
-
-        render_pass.draw(0..4, 0..1);
+        inner.render(queue, render_pass, target_format, device, color);
     }
 
     pub(super) fn reset(&self) {
         *self.inner.lock() = None;
     }
 }
+
+// ---------------------------------------------------------------------------
+// Native implementation (push constants)
+// ---------------------------------------------------------------------------
+
+#[cfg(not(target_arch = "wasm32"))]
+mod native {
+    use super::{HashMap, PipelineCompilationOptions, PushConstant, PUSH_CONSTANT_SIZE};
+
+    pub(super) struct ViewportClearInner {
+        pipeline_layout: wgpu::PipelineLayout,
+        shader: wgpu::ShaderModule,
+        pipelines: HashMap<wgpu::TextureFormat, wgpu::RenderPipeline>,
+    }
+
+    impl ViewportClearInner {
+        pub(super) fn new(device: &wgpu::Device) -> Self {
+            let pipeline_layout =
+                device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+                    label: Some("atlas_viewport_clear_pipeline_layout"),
+                    bind_group_layouts: &[],
+                    push_constant_ranges: &[wgpu::PushConstantRange {
+                        stages: wgpu::ShaderStages::FRAGMENT,
+                        range: 0..PUSH_CONSTANT_SIZE,
+                    }],
+                });
+            let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+                label: Some("atlas_viewport_clear_shader"),
+                source: wgpu::ShaderSource::Wgsl(
+                    include_str!("viewport_clear.wgsl").into(),
+                ),
+            });
+            Self {
+                pipeline_layout,
+                shader,
+                pipelines: HashMap::new(),
+            }
+        }
+
+        fn pipeline(
+            &mut self,
+            device: &wgpu::Device,
+            format: wgpu::TextureFormat,
+        ) -> &wgpu::RenderPipeline {
+            let shader = &self.shader;
+            let pipeline_layout = &self.pipeline_layout;
+            self.pipelines.entry(format).or_insert_with(|| {
+                device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+                    label: Some("atlas_viewport_clear_pipeline"),
+                    layout: Some(pipeline_layout),
+                    vertex: wgpu::VertexState {
+                        module: shader,
+                        entry_point: Some("vs_main"),
+                        buffers: &[],
+                        compilation_options: PipelineCompilationOptions::default(),
+                    },
+                    fragment: Some(wgpu::FragmentState {
+                        module: shader,
+                        entry_point: Some("fs_main"),
+                        targets: &[Some(wgpu::ColorTargetState {
+                            format,
+                            blend: Some(wgpu::BlendState::REPLACE),
+                            write_mask: wgpu::ColorWrites::ALL,
+                        })],
+                        compilation_options: PipelineCompilationOptions::default(),
+                    }),
+                    primitive: wgpu::PrimitiveState {
+                        topology: wgpu::PrimitiveTopology::TriangleStrip,
+                        cull_mode: None,
+                        ..Default::default()
+                    },
+                    depth_stencil: None,
+                    multisample: wgpu::MultisampleState::default(),
+                    multiview: None,
+                    cache: None,
+                })
+            })
+        }
+
+        pub(super) fn render(
+            &mut self,
+            _queue: &wgpu::Queue,
+            render_pass: &mut wgpu::RenderPass<'_>,
+            target_format: wgpu::TextureFormat,
+            device: &wgpu::Device,
+            color: [f32; 4],
+        ) {
+            let pipeline = self.pipeline(device, target_format);
+            render_pass.set_pipeline(pipeline);
+            render_pass.set_push_constants(
+                wgpu::ShaderStages::FRAGMENT,
+                0,
+                bytemuck::bytes_of(&PushConstant { color }),
+            );
+            render_pass.draw(0..4, 0..1);
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// WASM implementation (uniform buffer)
+// ---------------------------------------------------------------------------
+
+#[cfg(target_arch = "wasm32")]
+mod wasm {
+    use super::{HashMap, PipelineCompilationOptions, PushConstant};
+
+    pub(super) struct ViewportClearInner {
+        pipeline_layout: wgpu::PipelineLayout,
+        shader: wgpu::ShaderModule,
+        pipelines: HashMap<wgpu::TextureFormat, wgpu::RenderPipeline>,
+        uniform_buffer: wgpu::Buffer,
+        bind_group_layout: wgpu::BindGroupLayout,
+        bind_group: wgpu::BindGroup,
+    }
+
+    impl ViewportClearInner {
+        pub(super) fn new(device: &wgpu::Device) -> Self {
+            let bind_group_layout =
+                device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+                    label: Some("atlas_viewport_clear_bgl"),
+                    entries: &[wgpu::BindGroupLayoutEntry {
+                        binding: 0,
+                        visibility: wgpu::ShaderStages::FRAGMENT,
+                        ty: wgpu::BindingType::Buffer {
+                            ty: wgpu::BufferBindingType::Uniform,
+                            has_dynamic_offset: false,
+                            min_binding_size: None,
+                        },
+                        count: None,
+                    }],
+                });
+            let pipeline_layout =
+                device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+                    label: Some("atlas_viewport_clear_pipeline_layout"),
+                    bind_group_layouts: &[&bind_group_layout],
+                    push_constant_ranges: &[],
+                });
+            let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+                label: Some("atlas_viewport_clear_shader"),
+                source: wgpu::ShaderSource::Wgsl(
+                    include_str!("viewport_clear_web.wgsl").into(),
+                ),
+            });
+            let uniform_buffer = device.create_buffer(&wgpu::BufferDescriptor {
+                label: Some("atlas_viewport_clear_uniform"),
+                size: 16,
+                usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
+                mapped_at_creation: false,
+            });
+            let bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
+                label: Some("atlas_viewport_clear_bind_group"),
+                layout: &bind_group_layout,
+                entries: &[wgpu::BindGroupEntry {
+                    binding: 0,
+                    resource: uniform_buffer.as_entire_binding(),
+                }],
+            });
+            Self {
+                pipeline_layout,
+                shader,
+                pipelines: HashMap::new(),
+                uniform_buffer,
+                bind_group_layout,
+                bind_group,
+            }
+        }
+
+        fn pipeline(
+            &mut self,
+            device: &wgpu::Device,
+            format: wgpu::TextureFormat,
+        ) -> &wgpu::RenderPipeline {
+            let shader = &self.shader;
+            let pipeline_layout = &self.pipeline_layout;
+            self.pipelines.entry(format).or_insert_with(|| {
+                device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+                    label: Some("atlas_viewport_clear_pipeline"),
+                    layout: Some(pipeline_layout),
+                    vertex: wgpu::VertexState {
+                        module: shader,
+                        entry_point: Some("vs_main"),
+                        buffers: &[],
+                        compilation_options: PipelineCompilationOptions::default(),
+                    },
+                    fragment: Some(wgpu::FragmentState {
+                        module: shader,
+                        entry_point: Some("fs_main"),
+                        targets: &[Some(wgpu::ColorTargetState {
+                            format,
+                            blend: Some(wgpu::BlendState::REPLACE),
+                            write_mask: wgpu::ColorWrites::ALL,
+                        })],
+                        compilation_options: PipelineCompilationOptions::default(),
+                    }),
+                    primitive: wgpu::PrimitiveState {
+                        topology: wgpu::PrimitiveTopology::TriangleStrip,
+                        cull_mode: None,
+                        ..Default::default()
+                    },
+                    depth_stencil: None,
+                    multisample: wgpu::MultisampleState::default(),
+                    multiview: None,
+                    cache: None,
+                })
+            })
+        }
+
+        pub(super) fn render(
+            &mut self,
+            queue: &wgpu::Queue,
+            render_pass: &mut wgpu::RenderPass<'_>,
+            target_format: wgpu::TextureFormat,
+            device: &wgpu::Device,
+            color: [f32; 4],
+        ) {
+            let pipeline = self.pipeline(device, target_format);
+            render_pass.set_pipeline(pipeline);
+            queue.write_buffer(
+                &self.uniform_buffer,
+                0,
+                bytemuck::bytes_of(&PushConstant { color }),
+            );
+            render_pass.set_bind_group(0, &self.bind_group, &[]);
+            render_pass.draw(0..4, 0..1);
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+
+#[cfg(not(target_arch = "wasm32"))]
+use native::ViewportClearInner;
+#[cfg(target_arch = "wasm32")]
+use wasm::ViewportClearInner;

--- a/gpu-utils/src/texture_atlas/atlas_simple/atlas/viewport_clear.rs
+++ b/gpu-utils/src/texture_atlas/atlas_simple/atlas/viewport_clear.rs
@@ -12,6 +12,12 @@ struct ViewportClearInner {
     pipeline_layout: wgpu::PipelineLayout,
     shader: wgpu::ShaderModule,
     pipelines: HashMap<wgpu::TextureFormat, wgpu::RenderPipeline>,
+    #[cfg(target_arch = "wasm32")]
+    uniform_buffer: wgpu::Buffer,
+    #[cfg(target_arch = "wasm32")]
+    bind_group_layout: wgpu::BindGroupLayout,
+    #[cfg(target_arch = "wasm32")]
+    bind_group: wgpu::BindGroup,
 }
 
 #[repr(C)]
@@ -24,24 +30,83 @@ const PUSH_CONSTANT_SIZE: u32 = std::mem::size_of::<PushConstant>() as u32;
 
 impl ViewportClearInner {
     fn new(device: &wgpu::Device) -> Self {
-        let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
-            label: Some("atlas_viewport_clear_pipeline_layout"),
-            bind_group_layouts: &[],
-            push_constant_ranges: &[wgpu::PushConstantRange {
-                stages: wgpu::ShaderStages::FRAGMENT,
-                range: 0..PUSH_CONSTANT_SIZE,
-            }],
-        });
+        #[cfg(not(target_arch = "wasm32"))]
+        let (pipeline_layout, bgl_opt) = {
+            let layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+                label: Some("atlas_viewport_clear_pipeline_layout"),
+                bind_group_layouts: &[],
+                push_constant_ranges: &[wgpu::PushConstantRange {
+                    stages: wgpu::ShaderStages::FRAGMENT,
+                    range: 0..PUSH_CONSTANT_SIZE,
+                }],
+            });
+            (layout, ())
+        };
+
+        #[cfg(target_arch = "wasm32")]
+        let (pipeline_layout, bgl_opt) = {
+            let bgl = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+                label: Some("atlas_viewport_clear_bgl"),
+                entries: &[wgpu::BindGroupLayoutEntry {
+                    binding: 0,
+                    visibility: wgpu::ShaderStages::FRAGMENT,
+                    ty: wgpu::BindingType::Buffer {
+                        ty: wgpu::BufferBindingType::Uniform,
+                        has_dynamic_offset: false,
+                        min_binding_size: None,
+                    },
+                    count: None,
+                }],
+            });
+            let layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+                label: Some("atlas_viewport_clear_pipeline_layout"),
+                bind_group_layouts: &[&bgl],
+                push_constant_ranges: &[],
+            });
+            (layout, bgl)
+        };
+
+        #[cfg(not(target_arch = "wasm32"))]
+        let src = include_str!("viewport_clear.wgsl");
+        #[cfg(target_arch = "wasm32")]
+        let src = include_str!("viewport_clear_web.wgsl");
 
         let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
             label: Some("atlas_viewport_clear_shader"),
-            source: wgpu::ShaderSource::Wgsl(include_str!("viewport_clear.wgsl").into()),
+            source: wgpu::ShaderSource::Wgsl(src.into()),
         });
+
+        #[cfg(target_arch = "wasm32")]
+        let uniform_buffer = device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("atlas_viewport_clear_uniform"),
+            size: 16,
+            usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
+            mapped_at_creation: false,
+        });
+
+        #[cfg(target_arch = "wasm32")]
+        let bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("atlas_viewport_clear_bind_group"),
+            layout: &bgl_opt,
+            entries: &[wgpu::BindGroupEntry {
+                binding: 0,
+                resource: uniform_buffer.as_entire_binding(),
+            }],
+        });
+
+        // suppress unused warning on native
+        let _ = &bgl_opt;
 
         ViewportClearInner {
             pipeline_layout,
             shader,
             pipelines: HashMap::new(),
+            #[cfg(target_arch = "wasm32")]
+            bind_group_layout: bgl_opt,
+            #[cfg(target_arch = "wasm32")]
+            uniform_buffer,
+            #[cfg(target_arch = "wasm32")]
+            bind_group,
         }
     }
 
@@ -51,10 +116,11 @@ impl ViewportClearInner {
         format: wgpu::TextureFormat,
     ) -> &wgpu::RenderPipeline {
         let shader = &self.shader;
+        let pipeline_layout = &self.pipeline_layout;
         self.pipelines.entry(format).or_insert_with(|| {
             device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
                 label: Some("atlas_viewport_clear_pipeline"),
-                layout: Some(&self.pipeline_layout),
+                layout: Some(pipeline_layout),
                 vertex: wgpu::VertexState {
                     module: shader,
                     entry_point: Some("vs_main"),
@@ -88,9 +154,10 @@ impl ViewportClearInner {
 impl ViewportClear {
     pub(super) fn render(
         &self,
-        device: &wgpu::Device,
+        queue: &wgpu::Queue,
         render_pass: &mut wgpu::RenderPass<'_>,
         target_format: wgpu::TextureFormat,
+        device: &wgpu::Device,
         color: [f32; 4],
     ) {
         let mut guard = self.inner.lock();
@@ -98,12 +165,23 @@ impl ViewportClear {
         let pipeline = inner.pipeline(device, target_format);
 
         render_pass.set_pipeline(pipeline);
+
         let constants = PushConstant { color };
+        #[cfg(not(target_arch = "wasm32"))]
         render_pass.set_push_constants(
             wgpu::ShaderStages::FRAGMENT,
             0,
             bytemuck::bytes_of(&constants),
         );
+        #[cfg(target_arch = "wasm32")]
+        {
+            queue.write_buffer(&inner.uniform_buffer, 0, bytemuck::bytes_of(&constants));
+            render_pass.set_bind_group(0, &inner.bind_group, &[]);
+        }
+
+        // suppress unused warning on native
+        let _ = queue;
+
         render_pass.draw(0..4, 0..1);
     }
 

--- a/gpu-utils/src/texture_atlas/atlas_simple/atlas/viewport_clear_web.wgsl
+++ b/gpu-utils/src/texture_atlas/atlas_simple/atlas/viewport_clear_web.wgsl
@@ -1,0 +1,22 @@
+@vertex
+fn vs_main(@builtin(vertex_index) vertex_index: u32) -> @builtin(position) vec4<f32> {
+    var positions = array<vec2<f32>, 4>(
+        vec2<f32>(-1.0, -1.0),
+        vec2<f32>(1.0, -1.0),
+        vec2<f32>(-1.0, 1.0),
+        vec2<f32>(1.0, 1.0),
+    );
+    let p = positions[vertex_index];
+    return vec4<f32>(p.x, p.y, 0.0, 1.0);
+}
+
+struct PushConstants {
+    color: vec4<f32>,
+};
+
+@group(0) @binding(0) var<uniform> pc: PushConstants;
+
+@fragment
+fn fs_main() -> @location(0) vec4<f32> {
+    return pc.color;
+}

--- a/gpu-utils/src/texture_atlas/atlas_simple/manager.rs
+++ b/gpu-utils/src/texture_atlas/atlas_simple/manager.rs
@@ -60,6 +60,7 @@ impl AtlasManager {
 
         let atlas = TextureAtlas::new(
             &self.device,
+            &self.queue,
             wgpu::Extent3d {
                 width: self.max_size_of_3d_texture.width,
                 height: self.max_size_of_3d_texture.height,

--- a/matcha-tree-widgets/src/style.rs
+++ b/matcha-tree-widgets/src/style.rs
@@ -11,11 +11,12 @@ use matcha_tree::ui_tree::{
     context::UiContext,
     metrics::{Constraints, QRect},
 };
+use utils::maybe_send_sync::MaybeSendSync;
 
 /// A trait that defines the visual appearance and drawing logic of a widget.
 ///
 /// This allows for custom rendering logic to be encapsulated and reused.
-pub trait Style: Send + Sync {
+pub trait Style: MaybeSendSync {
     /// Calculates the size required to draw this style within the given constraints.
     ///
     /// This method returns the intrinsic size of the visual content defined by the style,

--- a/matcha-tree-widgets/src/style/image.rs
+++ b/matcha-tree-widgets/src/style/image.rs
@@ -342,6 +342,7 @@ impl Style for Image {
 
             let texture_copy = TextureCopy::default();
             texture_copy.render(
+                ctx.gpu_queue(),
                 &mut render_pass,
                 TargetData {
                     target_size,

--- a/matcha-tree-widgets/src/style/polygon.rs
+++ b/matcha-tree-widgets/src/style/polygon.rs
@@ -16,9 +16,17 @@ use renderer::{
     widgets_renderer::vertex_color::{RenderData, TargetData, VertexColor},
 };
 
+#[cfg(not(target_arch = "wasm32"))]
 type PolygonFn = dyn for<'a> Fn([f32; 2], &'a UiContext) -> Mesh + Send + Sync + 'static;
+#[cfg(target_arch = "wasm32")]
+type PolygonFn = dyn for<'a> Fn([f32; 2], &'a UiContext) -> Mesh + 'static;
+
+#[cfg(not(target_arch = "wasm32"))]
 type AdaptFn =
     dyn for<'a> Fn([f32; 2], &'a UiContext) -> nalgebra::Matrix4<f32> + Send + Sync + 'static;
+#[cfg(target_arch = "wasm32")]
+type AdaptFn =
+    dyn for<'a> Fn([f32; 2], &'a UiContext) -> nalgebra::Matrix4<f32> + 'static;
 
 /// Quantize factor used for cache keying of matrices.
 /// Matches metrics SUB_PIXEL_QUANTIZE used for QSize / QRect quantization.
@@ -102,6 +110,7 @@ impl Polygon {
         }
     }
 
+    #[cfg(not(target_arch = "wasm32"))]
     pub fn new_adaptive<F>(polygon: F) -> Self
     where
         F: Fn([f32; 2], &UiContext) -> Mesh + Send + Sync + 'static,
@@ -115,9 +124,33 @@ impl Polygon {
         }
     }
 
+    #[cfg(target_arch = "wasm32")]
+    pub fn new_adaptive<F>(polygon: F) -> Self
+    where
+        F: Fn([f32; 2], &UiContext) -> Mesh + 'static,
+    {
+        Self {
+            polygon: Arc::new(polygon),
+            adaptive_affine: Arc::new(|_, _| nalgebra::Matrix4::identity()),
+            cache_the_mesh: true,
+            caches: Mutex::new(utils::cache::Cache::default()),
+            renderer: VertexColor::default(),
+        }
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
     pub fn adaptive_affine<F>(mut self, affine: F) -> Self
     where
         F: Fn([f32; 2], &UiContext) -> nalgebra::Matrix4<f32> + Send + Sync + 'static,
+    {
+        self.adaptive_affine = Arc::new(affine);
+        self
+    }
+
+    #[cfg(target_arch = "wasm32")]
+    pub fn adaptive_affine<F>(mut self, affine: F) -> Self
+    where
+        F: Fn([f32; 2], &UiContext) -> nalgebra::Matrix4<f32> + 'static,
     {
         self.adaptive_affine = Arc::new(affine);
         self

--- a/matcha-tree-widgets/src/style/polygon.rs
+++ b/matcha-tree-widgets/src/style/polygon.rs
@@ -455,6 +455,7 @@ impl Style for Polygon {
 
         // Pass adaptive_affine through RenderData so renderer can compose final push-constant matrix.
         self.renderer.render(
+            ctx.gpu_queue(),
             &mut render_pass,
             TargetData {
                 target_size,

--- a/matcha-tree-widgets/src/style/polygon.rs
+++ b/matcha-tree-widgets/src/style/polygon.rs
@@ -16,17 +16,55 @@ use renderer::{
     widgets_renderer::vertex_color::{RenderData, TargetData, VertexColor},
 };
 
-#[cfg(not(target_arch = "wasm32"))]
-type PolygonFn = dyn for<'a> Fn([f32; 2], &'a UiContext) -> Mesh + Send + Sync + 'static;
-#[cfg(target_arch = "wasm32")]
-type PolygonFn = dyn for<'a> Fn([f32; 2], &'a UiContext) -> Mesh + 'static;
+// ---------------------------------------------------------------------------
+// Platform-specific function types and bounds
+// ---------------------------------------------------------------------------
 
 #[cfg(not(target_arch = "wasm32"))]
-type AdaptFn =
-    dyn for<'a> Fn([f32; 2], &'a UiContext) -> nalgebra::Matrix4<f32> + Send + Sync + 'static;
+mod platform {
+    use super::{Mesh, UiContext};
+    pub type PolygonFn =
+        dyn for<'a> Fn([f32; 2], &'a UiContext) -> Mesh + Send + Sync + 'static;
+    pub type AdaptFn =
+        dyn for<'a> Fn([f32; 2], &'a UiContext) -> nalgebra::Matrix4<f32> + Send + Sync + 'static;
+    pub trait PolygonFnBound:
+        for<'a> Fn([f32; 2], &'a UiContext) -> Mesh + Send + Sync + 'static
+    {
+    }
+    impl<T: for<'a> Fn([f32; 2], &'a UiContext) -> Mesh + Send + Sync + 'static> PolygonFnBound
+        for T
+    {
+    }
+    pub trait AdaptFnBound:
+        for<'a> Fn([f32; 2], &'a UiContext) -> nalgebra::Matrix4<f32> + Send + Sync + 'static
+    {
+    }
+    impl<
+        T: for<'a> Fn([f32; 2], &'a UiContext) -> nalgebra::Matrix4<f32> + Send + Sync + 'static,
+    > AdaptFnBound for T
+    {
+    }
+}
+
 #[cfg(target_arch = "wasm32")]
-type AdaptFn =
-    dyn for<'a> Fn([f32; 2], &'a UiContext) -> nalgebra::Matrix4<f32> + 'static;
+mod platform {
+    use super::{Mesh, UiContext};
+    pub type PolygonFn = dyn for<'a> Fn([f32; 2], &'a UiContext) -> Mesh + 'static;
+    pub type AdaptFn =
+        dyn for<'a> Fn([f32; 2], &'a UiContext) -> nalgebra::Matrix4<f32> + 'static;
+    pub trait PolygonFnBound: for<'a> Fn([f32; 2], &'a UiContext) -> Mesh + 'static {}
+    impl<T: for<'a> Fn([f32; 2], &'a UiContext) -> Mesh + 'static> PolygonFnBound for T {}
+    pub trait AdaptFnBound:
+        for<'a> Fn([f32; 2], &'a UiContext) -> nalgebra::Matrix4<f32> + 'static
+    {
+    }
+    impl<T: for<'a> Fn([f32; 2], &'a UiContext) -> nalgebra::Matrix4<f32> + 'static>
+        AdaptFnBound for T
+    {
+    }
+}
+
+use platform::{AdaptFn, PolygonFn};
 
 /// Quantize factor used for cache keying of matrices.
 /// Matches metrics SUB_PIXEL_QUANTIZE used for QSize / QRect quantization.
@@ -110,11 +148,7 @@ impl Polygon {
         }
     }
 
-    #[cfg(not(target_arch = "wasm32"))]
-    pub fn new_adaptive<F>(polygon: F) -> Self
-    where
-        F: Fn([f32; 2], &UiContext) -> Mesh + Send + Sync + 'static,
-    {
+    pub fn new_adaptive<F: platform::PolygonFnBound>(polygon: F) -> Self {
         Self {
             polygon: Arc::new(polygon),
             adaptive_affine: Arc::new(|_, _| nalgebra::Matrix4::identity()),
@@ -124,34 +158,7 @@ impl Polygon {
         }
     }
 
-    #[cfg(target_arch = "wasm32")]
-    pub fn new_adaptive<F>(polygon: F) -> Self
-    where
-        F: Fn([f32; 2], &UiContext) -> Mesh + 'static,
-    {
-        Self {
-            polygon: Arc::new(polygon),
-            adaptive_affine: Arc::new(|_, _| nalgebra::Matrix4::identity()),
-            cache_the_mesh: true,
-            caches: Mutex::new(utils::cache::Cache::default()),
-            renderer: VertexColor::default(),
-        }
-    }
-
-    #[cfg(not(target_arch = "wasm32"))]
-    pub fn adaptive_affine<F>(mut self, affine: F) -> Self
-    where
-        F: Fn([f32; 2], &UiContext) -> nalgebra::Matrix4<f32> + Send + Sync + 'static,
-    {
-        self.adaptive_affine = Arc::new(affine);
-        self
-    }
-
-    #[cfg(target_arch = "wasm32")]
-    pub fn adaptive_affine<F>(mut self, affine: F) -> Self
-    where
-        F: Fn([f32; 2], &UiContext) -> nalgebra::Matrix4<f32> + 'static,
-    {
+    pub fn adaptive_affine<F: platform::AdaptFnBound>(mut self, affine: F) -> Self {
         self.adaptive_affine = Arc::new(affine);
         self
     }

--- a/matcha-tree-widgets/src/style/solid_box.rs
+++ b/matcha-tree-widgets/src/style/solid_box.rs
@@ -81,6 +81,7 @@ impl Style for SolidBox {
         let indices: [u16; 6] = [0, 1, 2, 0, 2, 3];
 
         self.renderer.render(
+            ctx.gpu_queue(),
             &mut render_pass,
             TargetData {
                 target_size,

--- a/matcha-tree-widgets/src/style/text.rs
+++ b/matcha-tree-widgets/src/style/text.rs
@@ -373,6 +373,7 @@ impl crate::style::Style for TextRenderer {
         };
 
         self.texture_copy.render(
+            ctx.gpu_queue(),
             &mut render_pass,
             renderer::texture_copy::TargetData {
                 target_size: target.texture_size(),

--- a/matcha-tree-widgets/src/style/text_cosmic.rs
+++ b/matcha-tree-widgets/src/style/text_cosmic.rs
@@ -413,6 +413,7 @@ impl Style for TextCosmic<'static> {
         // Use TextureCopy to render the temporary texture into the atlas region.
         let texture_copy = TextureCopy::default();
         texture_copy.render(
+            ctx.gpu_queue(),
             &mut render_pass,
             TexTargetData {
                 target_size: target.size(),

--- a/matcha-tree-widgets/src/style/viewport_clear.rs
+++ b/matcha-tree-widgets/src/style/viewport_clear.rs
@@ -53,6 +53,7 @@ impl Style for ViewportClear {
         };
 
         self.renderer.render(
+            ctx.gpu_queue(),
             &mut render_pass,
             target_format,
             ctx.gpu_device(),

--- a/matcha-tree-widgets/src/types/size.rs
+++ b/matcha-tree-widgets/src/types/size.rs
@@ -47,7 +47,10 @@ impl ChildSize<'_> {
     }
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 type SizeFn = dyn Fn([f32; 2], &mut ChildSize, &UiContext) -> f32 + Send + Sync + 'static;
+#[cfg(target_arch = "wasm32")]
+type SizeFn = dyn Fn([f32; 2], &mut ChildSize, &UiContext) -> f32 + 'static;
 
 /// Calculate size from parent size child size and context.
 #[derive(Clone)]
@@ -160,9 +163,19 @@ impl Size {
 
 impl Size {
     /// Specify size with a custom function.
+    #[cfg(not(target_arch = "wasm32"))]
     pub fn from_size<F>(f: F) -> Self
     where
         F: Fn([f32; 2], &mut ChildSize, &UiContext) -> f32 + Send + Sync + 'static,
+    {
+        Self { f: Arc::new(f) }
+    }
+
+    /// Specify size with a custom function.
+    #[cfg(target_arch = "wasm32")]
+    pub fn from_size<F>(f: F) -> Self
+    where
+        F: Fn([f32; 2], &mut ChildSize, &UiContext) -> f32 + 'static,
     {
         Self { f: Arc::new(f) }
     }

--- a/matcha-tree-widgets/src/types/size.rs
+++ b/matcha-tree-widgets/src/types/size.rs
@@ -47,10 +47,34 @@ impl ChildSize<'_> {
     }
 }
 
+// ---------------------------------------------------------------------------
+// Platform-specific function type and bound — single cfg block per platform
+// ---------------------------------------------------------------------------
+
 #[cfg(not(target_arch = "wasm32"))]
-type SizeFn = dyn Fn([f32; 2], &mut ChildSize, &UiContext) -> f32 + Send + Sync + 'static;
+mod platform {
+    use super::{ChildSize, UiContext};
+    pub type SizeFn =
+        dyn Fn([f32; 2], &mut ChildSize, &UiContext) -> f32 + Send + Sync + 'static;
+    pub trait SizeFnBound:
+        Fn([f32; 2], &mut ChildSize, &UiContext) -> f32 + Send + Sync + 'static
+    {
+    }
+    impl<T: Fn([f32; 2], &mut ChildSize, &UiContext) -> f32 + Send + Sync + 'static>
+        SizeFnBound for T
+    {
+    }
+}
+
 #[cfg(target_arch = "wasm32")]
-type SizeFn = dyn Fn([f32; 2], &mut ChildSize, &UiContext) -> f32 + 'static;
+mod platform {
+    use super::{ChildSize, UiContext};
+    pub type SizeFn = dyn Fn([f32; 2], &mut ChildSize, &UiContext) -> f32 + 'static;
+    pub trait SizeFnBound: Fn([f32; 2], &mut ChildSize, &UiContext) -> f32 + 'static {}
+    impl<T: Fn([f32; 2], &mut ChildSize, &UiContext) -> f32 + 'static> SizeFnBound for T {}
+}
+
+use platform::SizeFn;
 
 /// Calculate size from parent size child size and context.
 #[derive(Clone)]
@@ -163,20 +187,7 @@ impl Size {
 
 impl Size {
     /// Specify size with a custom function.
-    #[cfg(not(target_arch = "wasm32"))]
-    pub fn from_size<F>(f: F) -> Self
-    where
-        F: Fn([f32; 2], &mut ChildSize, &UiContext) -> f32 + Send + Sync + 'static,
-    {
-        Self { f: Arc::new(f) }
-    }
-
-    /// Specify size with a custom function.
-    #[cfg(target_arch = "wasm32")]
-    pub fn from_size<F>(f: F) -> Self
-    where
-        F: Fn([f32; 2], &mut ChildSize, &UiContext) -> f32 + 'static,
-    {
+    pub fn from_size<F: platform::SizeFnBound>(f: F) -> Self {
         Self { f: Arc::new(f) }
     }
 }

--- a/matcha-tree-widgets/src/widget/button.rs
+++ b/matcha-tree-widgets/src/widget/button.rs
@@ -21,7 +21,10 @@ use crate::style::Style as _;
 pub struct Button {
     pub label: Option<String>,
     pub content: Box<dyn View>,
+    #[cfg(not(target_arch = "wasm32"))]
     pub on_click: Option<Arc<dyn Fn(&UiContext) + Send + Sync>>,
+    #[cfg(target_arch = "wasm32")]
+    pub on_click: Option<Arc<dyn Fn(&UiContext)>>,
 }
 
 impl Button {
@@ -38,9 +41,19 @@ impl Button {
         self
     }
 
+    #[cfg(not(target_arch = "wasm32"))]
     pub fn on_click<F>(mut self, f: F) -> Self
     where
         F: Fn(&UiContext) + Send + Sync + 'static,
+    {
+        self.on_click = Some(Arc::new(f));
+        self
+    }
+
+    #[cfg(target_arch = "wasm32")]
+    pub fn on_click<F>(mut self, f: F) -> Self
+    where
+        F: Fn(&UiContext) + 'static,
     {
         self.on_click = Some(Arc::new(f));
         self
@@ -75,7 +88,10 @@ enum ButtonState {
 }
 
 pub struct ButtonWidget {
+    #[cfg(not(target_arch = "wasm32"))]
     on_click: Option<Arc<dyn Fn(&UiContext) + Send + Sync>>,
+    #[cfg(target_arch = "wasm32")]
+    on_click: Option<Arc<dyn Fn(&UiContext)>>,
     state: ButtonState,
     child: Option<WidgetPod>,
 }

--- a/matcha-tree-widgets/src/widget/button.rs
+++ b/matcha-tree-widgets/src/widget/button.rs
@@ -1,6 +1,28 @@
 use std::sync::Arc;
 
 use crate::layout::reconcile_single_child;
+
+// ---------------------------------------------------------------------------
+// Platform-specific on_click function type and bound
+// ---------------------------------------------------------------------------
+
+#[cfg(not(target_arch = "wasm32"))]
+mod platform {
+    use matcha_tree::ui_tree::context::UiContext;
+    pub type OnClickFn = dyn Fn(&UiContext) + Send + Sync;
+    pub trait OnClickBound: Fn(&UiContext) + Send + Sync + 'static {}
+    impl<T: Fn(&UiContext) + Send + Sync + 'static> OnClickBound for T {}
+}
+
+#[cfg(target_arch = "wasm32")]
+mod platform {
+    use matcha_tree::ui_tree::context::UiContext;
+    pub type OnClickFn = dyn Fn(&UiContext);
+    pub trait OnClickBound: Fn(&UiContext) + 'static {}
+    impl<T: Fn(&UiContext) + 'static> OnClickBound for T {}
+}
+
+use platform::OnClickFn;
 use crate::style::solid_box::SolidBox;
 use matcha_tree::color::Color;
 use matcha_tree::event::device_event::ElementState;
@@ -21,10 +43,7 @@ use crate::style::Style as _;
 pub struct Button {
     pub label: Option<String>,
     pub content: Box<dyn View>,
-    #[cfg(not(target_arch = "wasm32"))]
-    pub on_click: Option<Arc<dyn Fn(&UiContext) + Send + Sync>>,
-    #[cfg(target_arch = "wasm32")]
-    pub on_click: Option<Arc<dyn Fn(&UiContext)>>,
+    pub on_click: Option<Arc<OnClickFn>>,
 }
 
 impl Button {
@@ -41,20 +60,7 @@ impl Button {
         self
     }
 
-    #[cfg(not(target_arch = "wasm32"))]
-    pub fn on_click<F>(mut self, f: F) -> Self
-    where
-        F: Fn(&UiContext) + Send + Sync + 'static,
-    {
-        self.on_click = Some(Arc::new(f));
-        self
-    }
-
-    #[cfg(target_arch = "wasm32")]
-    pub fn on_click<F>(mut self, f: F) -> Self
-    where
-        F: Fn(&UiContext) + 'static,
-    {
+    pub fn on_click<F: platform::OnClickBound>(mut self, f: F) -> Self {
         self.on_click = Some(Arc::new(f));
         self
     }
@@ -88,10 +94,7 @@ enum ButtonState {
 }
 
 pub struct ButtonWidget {
-    #[cfg(not(target_arch = "wasm32"))]
-    on_click: Option<Arc<dyn Fn(&UiContext) + Send + Sync>>,
-    #[cfg(target_arch = "wasm32")]
-    on_click: Option<Arc<dyn Fn(&UiContext)>>,
+    on_click: Option<Arc<OnClickFn>>,
     state: ButtonState,
     child: Option<WidgetPod>,
 }

--- a/matcha-tree/src/ui_tree.rs
+++ b/matcha-tree/src/ui_tree.rs
@@ -12,11 +12,13 @@ use std::sync::{
     atomic::{AtomicBool, Ordering},
 };
 
+use matcha_window::RuntimeHandle;
 use matcha_window::adapter::{EventLoop, EventLoopProxy};
 use matcha_window::application::Application;
 use matcha_window::event::device_event::DeviceEvent;
 use matcha_window::event::raw_device_event::{RawDeviceEvent, RawDeviceId};
 use matcha_window::event::window_event::WindowEvent;
+use matcha_window::task_handle::TaskHandle;
 use matcha_window::window::WindowId;
 
 use component::{Component, ComponentPod};
@@ -65,7 +67,7 @@ pub struct UiTree<C: Component> {
 
     /// Handle to the bridge task spawned in `init()`.
     /// Set once; `OnceLock` provides `Sync` without a runtime mutex.
-    bridge_handle: OnceLock<tokio::task::JoinHandle<()>>,
+    bridge_handle: OnceLock<TaskHandle<()>>,
 
     /// Shared texture atlas for widget rendering (format: Rgba8UnormSrgb).
     texture_atlas: std::sync::Arc<TextureAtlas>,
@@ -88,9 +90,10 @@ impl<C: Component> UiTree<C> {
     pub fn new(root: C, gpu: gpu_utils::gpu::Gpu) -> Self {
         let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
 
-        let (gpu_device, _) = gpu.context().unwrap();
+        let (gpu_device, gpu_queue) = gpu.context().unwrap();
         let texture_atlas = TextureAtlas::new(
             &gpu_device,
+            &gpu_queue,
             wgpu::Extent3d {
                 width: 4096,
                 height: 4096,
@@ -102,6 +105,7 @@ impl<C: Component> UiTree<C> {
 
         let stencil_atlas = TextureAtlas::new(
             &gpu_device,
+            &gpu_queue,
             wgpu::Extent3d {
                 width: 4096,
                 height: 4096,
@@ -145,7 +149,7 @@ impl<C: Component> UiTree<C> {
     /// reconciles the widget tree.  Prunes dead window registry entries.
     fn run_update(
         &self,
-        runtime: &tokio::runtime::Handle,
+        runtime: &RuntimeHandle,
         event_loop: &dyn EventLoop,
         gpu: &gpu_utils::gpu::Gpu,
     ) {
@@ -192,7 +196,8 @@ impl<C: Component> UiTree<C> {
 // Application impl
 // ----------------------------------------------------------------------------
 
-#[async_trait::async_trait]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 impl<C: Component> Application for UiTree<C> {
     type Command = TreeAppCommand<C::Message>;
 
@@ -202,7 +207,7 @@ impl<C: Component> Application for UiTree<C> {
 
     fn init(
         &mut self,
-        runtime: &tokio::runtime::Handle,
+        runtime: &RuntimeHandle,
         proxy: Box<dyn EventLoopProxy<Self> + Send>,
         event_loop: &impl EventLoop,
     ) {
@@ -251,7 +256,7 @@ impl<C: Component> Application for UiTree<C> {
         self.root.init(&ctx);
     }
 
-    fn resumed(&self, runtime: &tokio::runtime::Handle, event_loop: &impl EventLoop) {
+    fn resumed(&self, runtime: &RuntimeHandle, event_loop: &impl EventLoop) {
         let ctx = AppContext {
             runtime_handle: runtime,
             event_sender: &self.event_sender,
@@ -263,7 +268,7 @@ impl<C: Component> Application for UiTree<C> {
     /// Builds the initial widget tree (creates OS windows declared in the view).
     ///
     /// Called by [`Adapter`](crate::adapter::Adapter) immediately after `resumed`.
-    fn create_surface(&self, runtime: &tokio::runtime::Handle, event_loop: &impl EventLoop) {
+    fn create_surface(&self, runtime: &RuntimeHandle, event_loop: &impl EventLoop) {
         self.surface_creation_permitted
             .store(true, Ordering::SeqCst);
 
@@ -284,7 +289,7 @@ impl<C: Component> Application for UiTree<C> {
     ///
     /// Dead `Weak` entries in the window registry are pruned on the next
     /// `create_window` / `buffer_updated` call.
-    fn destroy_surface(&self, _runtime: &tokio::runtime::Handle, _event_loop: &impl EventLoop) {
+    fn destroy_surface(&self, _runtime: &RuntimeHandle, _event_loop: &impl EventLoop) {
         self.surface_creation_permitted
             .store(false, Ordering::SeqCst);
 
@@ -296,7 +301,7 @@ impl<C: Component> Application for UiTree<C> {
         }
     }
 
-    fn suspended(&self, runtime: &tokio::runtime::Handle, event_loop: &impl EventLoop) {
+    fn suspended(&self, runtime: &RuntimeHandle, event_loop: &impl EventLoop) {
         let ctx = AppContext {
             runtime_handle: runtime,
             event_sender: &self.event_sender,
@@ -305,7 +310,7 @@ impl<C: Component> Application for UiTree<C> {
         self.root.suspended(&ctx);
     }
 
-    fn exiting(&self, runtime: &tokio::runtime::Handle, event_loop: &impl EventLoop) {
+    fn exiting(&self, runtime: &RuntimeHandle, event_loop: &impl EventLoop) {
         let ctx = AppContext {
             runtime_handle: runtime,
             event_sender: &self.event_sender,
@@ -322,7 +327,7 @@ impl<C: Component> Application for UiTree<C> {
     /// [`RenderNode`](renderer::RenderNode).
     ///
     /// GPU surface submission is now implemented.
-    async fn render(&self, runtime: &tokio::runtime::Handle, window_id: WindowId) {
+    async fn render(&self, runtime: &RuntimeHandle, window_id: WindowId) {
         let op_arc = self
             .window_registry
             .get(&window_id)
@@ -364,7 +369,7 @@ impl<C: Component> Application for UiTree<C> {
 
     fn window_event(
         &self,
-        runtime: &tokio::runtime::Handle,
+        runtime: &RuntimeHandle,
         event_loop: &impl EventLoop,
         window_id: WindowId,
         event: WindowEvent,
@@ -374,7 +379,7 @@ impl<C: Component> Application for UiTree<C> {
 
     fn window_destroyed(
         &self,
-        runtime: &tokio::runtime::Handle,
+        runtime: &RuntimeHandle,
         event_loop: &impl EventLoop,
         window_id: WindowId,
     ) {
@@ -384,7 +389,7 @@ impl<C: Component> Application for UiTree<C> {
     /// Routes a device event to the widget tree of the target window.
     fn device_event(
         &self,
-        runtime: &tokio::runtime::Handle,
+        runtime: &RuntimeHandle,
         event_loop: &impl EventLoop,
         window_id: WindowId,
         event: DeviceEvent,
@@ -421,7 +426,7 @@ impl<C: Component> Application for UiTree<C> {
 
     fn raw_device_event(
         &self,
-        runtime: &tokio::runtime::Handle,
+        runtime: &RuntimeHandle,
         event_loop: &impl EventLoop,
         raw_device_id: RawDeviceId,
         raw_event: RawDeviceEvent,
@@ -435,7 +440,7 @@ impl<C: Component> Application for UiTree<C> {
 
     fn ui_command(
         &self,
-        runtime: &tokio::runtime::Handle,
+        runtime: &RuntimeHandle,
         event_loop: &impl EventLoop,
         command: Self::Command,
     ) {

--- a/matcha-tree/src/ui_tree/component.rs
+++ b/matcha-tree/src/ui_tree/component.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use renderer::RenderNode;
+use utils::maybe_send_sync::MaybeSendSync;
 
 use super::widget::{View, Widget, WidgetInteractionResult, WidgetPod};
 use crate::ui_tree::{
@@ -41,9 +42,9 @@ use matcha_window::window::WindowId;
 ///
 /// Widgets emit events via `ctx.emit_event(Box<dyn Any + Send>)` rather than
 /// returning typed events. The application layer receives and downcasts them.
-pub trait Component: Send + Sync + 'static {
+pub trait Component: MaybeSendSync + 'static {
     /// Discrete commands delivered from the application layer.
-    type Message: Send + Sync + 'static;
+    type Message: MaybeSendSync + Send + 'static;
 
     // -----------------
     // Lifecycle methods

--- a/matcha-tree/src/ui_tree/context.rs
+++ b/matcha-tree/src/ui_tree/context.rs
@@ -5,6 +5,7 @@ use std::sync::Weak;
 use std::{any::Any, sync::Arc};
 
 use super::window::AnyWindowWidgetInstance;
+use matcha_window::RuntimeHandle;
 use matcha_window::adapter::EventLoop;
 use matcha_window::window::WindowId;
 use matcha_window::window::{Window, WindowConfig, WindowError};
@@ -59,13 +60,13 @@ impl EventReceiver {
 
 /// Context passed to Component lifecycle methods (init, resumed, suspended, exiting).
 pub struct AppContext<'a> {
-    pub(super) runtime_handle: &'a tokio::runtime::Handle,
+    pub(super) runtime_handle: &'a RuntimeHandle,
     pub(super) event_sender: &'a EventSender,
     pub(super) event_loop: &'a dyn EventLoop,
 }
 
 impl<'a> AppContext<'a> {
-    pub fn runtime_handle(&self) -> tokio::runtime::Handle {
+    pub fn runtime_handle(&self) -> RuntimeHandle {
         self.runtime_handle.clone()
     }
 
@@ -94,7 +95,7 @@ impl<'a> AppContext<'a> {
 /// Lives on the caller's stack and is borrowed by [`UiContext`].
 /// Adding new resources here does not change `UiContext`'s stack size.
 pub(super) struct SharedCtx<'a> {
-    pub(super) runtime_handle: &'a tokio::runtime::Handle,
+    pub(super) runtime_handle: &'a RuntimeHandle,
     pub(super) event_sender: &'a EventSender,
     pub(super) window_registry: &'a DashMap<WindowId, Weak<Mutex<dyn AnyWindowWidgetInstance>>>,
     pub(super) gpu_instance: &'a wgpu::Instance,
@@ -167,7 +168,7 @@ impl UiContext<'_> {
         Ok(window)
     }
 
-    pub fn runtime_handle(&self) -> tokio::runtime::Handle {
+    pub fn runtime_handle(&self) -> RuntimeHandle {
         self.shared.runtime_handle.clone()
     }
 

--- a/matcha-tree/src/ui_tree/widget.rs
+++ b/matcha-tree/src/ui_tree/widget.rs
@@ -1,6 +1,7 @@
 use std::any::Any;
 
 use renderer::render_node::RenderNode;
+use utils::maybe_send_sync::MaybeSendSync;
 
 use super::metrics;
 use crate::ui_tree::context::UiContext;
@@ -29,11 +30,11 @@ pub enum WidgetInteractionResult {
 // Key Structs and Traits
 // ----------------------------------------------------------------------------
 
-pub trait View: Send + Sync + Any {
+pub trait View: MaybeSendSync + Any {
     fn build(&self, ctx: &UiContext) -> WidgetPod;
 }
 
-pub trait Widget: Send + Sync + Any {
+pub trait Widget: MaybeSendSync + Any {
     type View: View;
 
     fn update(&mut self, view: &Self::View, ctx: &UiContext) -> WidgetInteractionResult;
@@ -60,7 +61,7 @@ pub trait Widget: Send + Sync + Any {
 }
 
 /// Wrapper trait to erase the concrete Widget type.
-pub(super) trait AnyWidget: Send + Sync + Any {
+pub(super) trait AnyWidget: MaybeSendSync + Any {
     fn try_update(
         &mut self,
         view: &dyn View,

--- a/matcha-tree/src/ui_tree/window.rs
+++ b/matcha-tree/src/ui_tree/window.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use parking_lot::Mutex;
 use renderer::RenderNode;
+use utils::maybe_send_sync::MaybeSendSync;
 
 use crate::ui_tree::{
     context::{UiContext, WindowCtx},
@@ -155,7 +156,7 @@ impl WindowWidgetInstance {
 /// when the window is removed from the view tree the widget is dropped, the `Arc` count
 /// reaches zero, and `UiArch`'s `Weak` becomes dead (window is destroyed automatically
 /// via [`WindowHandle`]'s [`Drop`] impl).
-pub trait AnyWindowWidgetInstance: Send + Sync {
+pub trait AnyWindowWidgetInstance: MaybeSendSync {
     fn window_id(&self) -> WindowId;
     fn size(&self) -> [f32; 2];
     fn device_input(&mut self, event: &DeviceEvent, ctx: &UiContext) -> WidgetInteractionResult;

--- a/matcha-window/Cargo.toml
+++ b/matcha-window/Cargo.toml
@@ -33,6 +33,10 @@ smallvec = { workspace = true }
 thiserror = { workspace = true }
 log = { workspace = true }
 enum-map = "2.7.3"
+web-time = "1"
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+tokio = { workspace = true, features = ["rt-multi-thread"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wasm-bindgen = "0.2"

--- a/matcha-window/Cargo.toml
+++ b/matcha-window/Cargo.toml
@@ -34,6 +34,11 @@ thiserror = { workspace = true }
 log = { workspace = true }
 enum-map = "2.7.3"
 
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+wasm-bindgen = "0.2"
+wasm-bindgen-futures = "0.4"
+web-sys = { version = "0.3", features = ["Window", "Document", "HtmlCanvasElement"] }
+
 [features]
 default = ["winit"]
 winit = ["dep:winit"]

--- a/matcha-window/src/adapter.rs
+++ b/matcha-window/src/adapter.rs
@@ -1,6 +1,7 @@
 use std::{collections::HashMap, sync::Arc};
 
 use crate::{
+    RuntimeHandle,
     application::Application,
     event::{
         EventStateConfig,
@@ -8,6 +9,7 @@ use crate::{
         raw_device_event::{RawDeviceEvent, RawDeviceId},
         window_event::{WindowEvent, WindowEventState},
     },
+    task_handle::TaskHandle,
     window::{WindowConfig, WindowError, WindowId, WindowSurface},
 };
 
@@ -35,9 +37,10 @@ impl PerWindowState {
 // ---------------------------------------------------------------------------
 
 pub struct Adapter<App: Application> {
+    #[cfg(not(target_arch = "wasm32"))]
     tokio_runtime: tokio::runtime::Runtime,
 
-    rendering_window: HashMap<WindowId, tokio::task::JoinHandle<()>>,
+    rendering_window: HashMap<WindowId, TaskHandle<()>>,
 
     /// Per-window event state machines, keyed by WindowId.
     /// Created lazily on the first event for a window;
@@ -52,10 +55,17 @@ pub struct Adapter<App: Application> {
 
 /// Construction
 impl<App: Application> Adapter<App> {
+    #[cfg(not(target_arch = "wasm32"))]
     pub fn new(app: App) -> Self {
         Self::with_tokio_runtime(app, tokio::runtime::Runtime::new().unwrap())
     }
 
+    #[cfg(target_arch = "wasm32")]
+    pub fn new(app: App) -> Self {
+        Self::wasm_new(app, EventStateConfig::default())
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
     pub fn with_event_config(app: App, event_config: EventStateConfig) -> Self {
         Self::with_tokio_runtime_and_event_config(
             app,
@@ -64,10 +74,17 @@ impl<App: Application> Adapter<App> {
         )
     }
 
+    #[cfg(target_arch = "wasm32")]
+    pub fn with_event_config(app: App, event_config: EventStateConfig) -> Self {
+        Self::wasm_new(app, event_config)
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
     pub fn with_tokio_runtime(app: App, runtime: tokio::runtime::Runtime) -> Self {
         Self::with_tokio_runtime_and_event_config(app, runtime, EventStateConfig::default())
     }
 
+    #[cfg(not(target_arch = "wasm32"))]
     pub fn with_tokio_runtime_and_event_config(
         app: App,
         runtime: tokio::runtime::Runtime,
@@ -75,6 +92,16 @@ impl<App: Application> Adapter<App> {
     ) -> Self {
         Self {
             tokio_runtime: runtime,
+            rendering_window: HashMap::new(),
+            window_states: HashMap::new(),
+            event_config,
+            app: Arc::new(app),
+        }
+    }
+
+    #[cfg(target_arch = "wasm32")]
+    fn wasm_new(app: App, event_config: EventStateConfig) -> Self {
+        Self {
             rendering_window: HashMap::new(),
             window_states: HashMap::new(),
             event_config,
@@ -107,40 +134,44 @@ impl<App: Application> Adapter<App> {
         proxy: Box<dyn EventLoopProxy<App> + Send>,
         event_loop: &impl EventLoop,
     ) {
+        let runtime = self.runtime_handle();
+        let _guard = runtime.enter();
         let app = Arc::get_mut(&mut self.app)
             .expect("Adapter::init must be called before any Arc clones are created");
-        let _guard = self.tokio_runtime.enter();
-        app.init(self.tokio_runtime.handle(), proxy, event_loop);
+        app.init(&runtime, proxy, event_loop);
     }
 
     pub fn resumed(&mut self, event_loop: &impl EventLoop) {
-        let _guard = self.tokio_runtime.enter();
-        self.app.resumed(self.tokio_runtime.handle(), event_loop);
+        let runtime = self.runtime_handle();
+        let _guard = runtime.enter();
+        self.app.resumed(&runtime, event_loop);
     }
 
     pub fn create_surface(&mut self, event_loop: &impl EventLoop) {
-        let _guard = self.tokio_runtime.enter();
-        self.app
-            .create_surface(self.tokio_runtime.handle(), event_loop);
+        let runtime = self.runtime_handle();
+        let _guard = runtime.enter();
+        self.app.create_surface(&runtime, event_loop);
     }
 
     pub fn destroy_surface(&mut self, event_loop: &impl EventLoop) {
         // ensure all rendering tasks are finished
         self.abort_all_rendering_tasks();
 
-        let _guard = self.tokio_runtime.enter();
-        self.app
-            .destroy_surface(self.tokio_runtime.handle(), event_loop);
+        let runtime = self.runtime_handle();
+        let _guard = runtime.enter();
+        self.app.destroy_surface(&runtime, event_loop);
     }
 
     pub fn suspended(&mut self, event_loop: &impl EventLoop) {
-        let _guard = self.tokio_runtime.enter();
-        self.app.suspended(self.tokio_runtime.handle(), event_loop);
+        let runtime = self.runtime_handle();
+        let _guard = runtime.enter();
+        self.app.suspended(&runtime, event_loop);
     }
 
     pub fn exiting(&mut self, event_loop: &impl EventLoop) {
-        let _guard = self.tokio_runtime.enter();
-        self.app.exiting(self.tokio_runtime.handle(), event_loop);
+        let runtime = self.runtime_handle();
+        let _guard = runtime.enter();
+        self.app.exiting(&runtime, event_loop);
     }
 }
 
@@ -152,18 +183,17 @@ impl<App: Application> Adapter<App> {
                 self.rendering_window.remove(&window_id);
             } else {
                 // request redraw again to catch up latest redraw request
-                self.app
-                    .request_redraw(self.tokio_runtime.handle(), window_id);
+                self.app.request_redraw(&self.runtime_handle(), window_id);
                 return;
             }
         }
 
         let app = self.app.clone();
-        let runtime_handle = self.tokio_runtime.handle().clone();
+        let runtime_handle = self.runtime_handle();
+        let runtime_in_task = runtime_handle.clone();
 
-        let handle = self.tokio_runtime.spawn(async move {
-            let handle = runtime_handle;
-            app.render(&handle, window_id).await;
+        let handle = runtime_handle.spawn(async move {
+            app.render(&runtime_in_task, window_id).await;
         });
 
         self.rendering_window.insert(window_id, handle);
@@ -175,10 +205,10 @@ impl<App: Application> Adapter<App> {
         window_id: WindowId,
         event: WindowEvent,
     ) {
-        let _guard = self.tokio_runtime.enter();
+        let runtime = self.runtime_handle();
+        let _guard = runtime.enter();
         let event = self.window_state_mut(window_id).window.process(event);
-        self.app
-            .window_event(self.tokio_runtime.handle(), event_loop, window_id, event);
+        self.app.window_event(&runtime, event_loop, window_id, event);
     }
 
     pub fn window_destroyed(&mut self, event_loop: &impl EventLoop, window_id: WindowId) {
@@ -187,9 +217,9 @@ impl<App: Application> Adapter<App> {
         // Clean up the rendering task for the window.
         self.remove_rendering_task(window_id);
         // Notify the Application that the window is gone.
-        let _guard = self.tokio_runtime.enter();
-        self.app
-            .window_destroyed(self.tokio_runtime.handle(), event_loop, window_id);
+        let runtime = self.runtime_handle();
+        let _guard = runtime.enter();
+        self.app.window_destroyed(&runtime, event_loop, window_id);
     }
 
     pub fn device_event(
@@ -199,13 +229,10 @@ impl<App: Application> Adapter<App> {
         event: DeviceEvent,
     ) {
         if let Some(processed) = self.window_state_mut(window_id).device.process(event) {
-            let _guard = self.tokio_runtime.enter();
-            self.app.device_event(
-                self.tokio_runtime.handle(),
-                event_loop,
-                window_id,
-                processed,
-            );
+            let runtime = self.runtime_handle();
+            let _guard = runtime.enter();
+            self.app
+                .device_event(&runtime, event_loop, window_id, processed);
         }
     }
 
@@ -215,30 +242,28 @@ impl<App: Application> Adapter<App> {
         raw_device_id: RawDeviceId,
         raw_event: RawDeviceEvent,
     ) {
-        let _guard = self.tokio_runtime.enter();
-        self.app.raw_device_event(
-            self.tokio_runtime.handle(),
-            event_loop,
-            raw_device_id,
-            raw_event,
-        );
+        let runtime = self.runtime_handle();
+        let _guard = runtime.enter();
+        self.app
+            .raw_device_event(&runtime, event_loop, raw_device_id, raw_event);
     }
 }
 
 /// Ui commands
 impl<App: Application> Adapter<App> {
     pub fn ui_command(&mut self, event_loop: &impl EventLoop, command: App::Command) {
-        let _guard = self.tokio_runtime.enter();
-        self.app
-            .ui_command(self.tokio_runtime.handle(), event_loop, command);
+        let runtime = self.runtime_handle();
+        let _guard = runtime.enter();
+        self.app.ui_command(&runtime, event_loop, command);
     }
 }
 
 /// Polling
 impl<App: Application> Adapter<App> {
     pub fn poll(&mut self, event_loop: &impl EventLoop) {
-        let _guard = self.tokio_runtime.enter();
-        self.app.poll(self.tokio_runtime.handle(), event_loop);
+        let runtime = self.runtime_handle();
+        let _guard = runtime.enter();
+        self.app.poll(&runtime, event_loop);
     }
 
     pub fn resume_time_reached(
@@ -247,13 +272,10 @@ impl<App: Application> Adapter<App> {
         start: std::time::Instant,
         requested_resume: std::time::Instant,
     ) {
-        let _guard = self.tokio_runtime.enter();
-        self.app.resume_time_reached(
-            self.tokio_runtime.handle(),
-            event_loop,
-            start,
-            requested_resume,
-        );
+        let runtime = self.runtime_handle();
+        let _guard = runtime.enter();
+        self.app
+            .resume_time_reached(&runtime, event_loop, start, requested_resume);
     }
 
     pub fn wait_cancelled(
@@ -262,27 +284,24 @@ impl<App: Application> Adapter<App> {
         start: std::time::Instant,
         requested_resume: Option<std::time::Instant>,
     ) {
-        let _guard = self.tokio_runtime.enter();
-        self.app.wait_cancelled(
-            self.tokio_runtime.handle(),
-            event_loop,
-            start,
-            requested_resume,
-        );
+        let runtime = self.runtime_handle();
+        let _guard = runtime.enter();
+        self.app
+            .wait_cancelled(&runtime, event_loop, start, requested_resume);
     }
 
     pub fn about_to_wait(&mut self, event_loop: &impl EventLoop) {
-        let _guard = self.tokio_runtime.enter();
-        self.app
-            .about_to_wait(self.tokio_runtime.handle(), event_loop);
+        let runtime = self.runtime_handle();
+        let _guard = runtime.enter();
+        self.app.about_to_wait(&runtime, event_loop);
     }
 }
 
 impl<App: Application> Adapter<App> {
     pub fn memory_warning(&mut self, event_loop: &impl EventLoop) {
-        let _guard = self.tokio_runtime.enter();
-        self.app
-            .memory_warning(self.tokio_runtime.handle(), event_loop);
+        let runtime = self.runtime_handle();
+        let _guard = runtime.enter();
+        self.app.memory_warning(&runtime, event_loop);
     }
 }
 
@@ -291,15 +310,31 @@ impl<App: Application> Adapter<App> {
 // -------------------
 
 impl<App: Application> Adapter<App> {
+    fn runtime_handle(&self) -> RuntimeHandle {
+        #[cfg(not(target_arch = "wasm32"))]
+        return RuntimeHandle::from_tokio(self.tokio_runtime.handle().clone());
+        #[cfg(target_arch = "wasm32")]
+        return RuntimeHandle;
+    }
+
     fn abort_all_rendering_tasks(&mut self) {
+        #[cfg(not(target_arch = "wasm32"))]
         self.tokio_runtime.block_on(async {
             for handle in self.rendering_window.values() {
                 handle.abort();
             }
             for (_, handle) in self.rendering_window.drain() {
-                let _ = handle.await;
+                let _ = handle.join().await;
             }
         });
+
+        #[cfg(target_arch = "wasm32")]
+        {
+            for handle in self.rendering_window.values() {
+                handle.abort();
+            }
+            self.rendering_window.clear();
+        }
     }
 
     fn remove_rendering_task(&mut self, window_id: WindowId) {

--- a/matcha-window/src/adapter.rs
+++ b/matcha-window/src/adapter.rs
@@ -269,8 +269,8 @@ impl<App: Application> Adapter<App> {
     pub fn resume_time_reached(
         &mut self,
         event_loop: &impl EventLoop,
-        start: std::time::Instant,
-        requested_resume: std::time::Instant,
+        start: web_time::Instant,
+        requested_resume: web_time::Instant,
     ) {
         let runtime = self.runtime_handle();
         let _guard = runtime.enter();
@@ -281,8 +281,8 @@ impl<App: Application> Adapter<App> {
     pub fn wait_cancelled(
         &mut self,
         event_loop: &impl EventLoop,
-        start: std::time::Instant,
-        requested_resume: Option<std::time::Instant>,
+        start: web_time::Instant,
+        requested_resume: Option<web_time::Instant>,
     ) {
         let runtime = self.runtime_handle();
         let _guard = runtime.enter();
@@ -392,7 +392,7 @@ pub enum EventLoopCommand {
 pub enum ControlFlow {
     Wait,
     Poll,
-    WaitUntil(std::time::Instant),
+    WaitUntil(web_time::Instant),
 }
 
 pub trait EventLoopProxy<App: Application>: Send {

--- a/matcha-window/src/adapter.rs
+++ b/matcha-window/src/adapter.rs
@@ -14,6 +14,78 @@ use crate::{
 };
 
 // ---------------------------------------------------------------------------
+// Platform-specific runtime state
+// ---------------------------------------------------------------------------
+
+#[cfg(not(target_arch = "wasm32"))]
+mod runtime_state {
+    use super::{HashMap, TaskHandle, WindowId};
+
+    pub(super) struct RuntimeState {
+        tokio_runtime: tokio::runtime::Runtime,
+    }
+
+    impl RuntimeState {
+        pub(super) fn new() -> Self {
+            Self {
+                tokio_runtime: tokio::runtime::Runtime::new().unwrap(),
+            }
+        }
+
+        pub(super) fn with_runtime(tokio_runtime: tokio::runtime::Runtime) -> Self {
+            Self { tokio_runtime }
+        }
+
+        pub(super) fn handle(&self) -> crate::RuntimeHandle {
+            crate::RuntimeHandle::from_tokio(self.tokio_runtime.handle().clone())
+        }
+
+        pub(super) fn abort_all_tasks(
+            &self,
+            rendering_window: &mut HashMap<WindowId, TaskHandle<()>>,
+        ) {
+            self.tokio_runtime.block_on(async {
+                for handle in rendering_window.values() {
+                    handle.abort();
+                }
+                for (_, handle) in rendering_window.drain() {
+                    let _ = handle.join().await;
+                }
+            });
+        }
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+mod runtime_state {
+    use super::{HashMap, TaskHandle, WindowId};
+
+    pub(super) struct RuntimeState;
+
+    impl RuntimeState {
+        pub(super) fn new() -> Self {
+            Self
+        }
+
+        pub(super) fn handle(&self) -> crate::RuntimeHandle {
+            crate::RuntimeHandle
+        }
+
+        pub(super) fn abort_all_tasks(
+            &self,
+            rendering_window: &mut HashMap<WindowId, TaskHandle<()>>,
+        ) {
+            for handle in rendering_window.values() {
+                handle.abort();
+            }
+            rendering_window.clear();
+        }
+    }
+}
+
+use runtime_state::RuntimeState;
+
+// ---------------------------------------------------------------------------
 // Per-window state machines
 // ---------------------------------------------------------------------------
 
@@ -37,51 +109,34 @@ impl PerWindowState {
 // ---------------------------------------------------------------------------
 
 pub struct Adapter<App: Application> {
-    #[cfg(not(target_arch = "wasm32"))]
-    tokio_runtime: tokio::runtime::Runtime,
-
+    runtime: RuntimeState,
     rendering_window: HashMap<WindowId, TaskHandle<()>>,
-
     /// Per-window event state machines, keyed by WindowId.
     /// Created lazily on the first event for a window;
     /// removed when `WindowEvent::Destroyed` is received.
     window_states: HashMap<WindowId, PerWindowState>,
-
     /// Configuration applied to every new per-window state machine.
     event_config: EventStateConfig,
-
     app: Arc<App>,
 }
 
 /// Construction
 impl<App: Application> Adapter<App> {
-    #[cfg(not(target_arch = "wasm32"))]
     pub fn new(app: App) -> Self {
-        Self::with_tokio_runtime(app, tokio::runtime::Runtime::new().unwrap())
+        Self::with_runtime_and_event_config(RuntimeState::new(), app, EventStateConfig::default())
     }
 
-    #[cfg(target_arch = "wasm32")]
-    pub fn new(app: App) -> Self {
-        Self::wasm_new(app, EventStateConfig::default())
-    }
-
-    #[cfg(not(target_arch = "wasm32"))]
     pub fn with_event_config(app: App, event_config: EventStateConfig) -> Self {
-        Self::with_tokio_runtime_and_event_config(
-            app,
-            tokio::runtime::Runtime::new().unwrap(),
-            event_config,
-        )
-    }
-
-    #[cfg(target_arch = "wasm32")]
-    pub fn with_event_config(app: App, event_config: EventStateConfig) -> Self {
-        Self::wasm_new(app, event_config)
+        Self::with_runtime_and_event_config(RuntimeState::new(), app, event_config)
     }
 
     #[cfg(not(target_arch = "wasm32"))]
     pub fn with_tokio_runtime(app: App, runtime: tokio::runtime::Runtime) -> Self {
-        Self::with_tokio_runtime_and_event_config(app, runtime, EventStateConfig::default())
+        Self::with_runtime_and_event_config(
+            RuntimeState::with_runtime(runtime),
+            app,
+            EventStateConfig::default(),
+        )
     }
 
     #[cfg(not(target_arch = "wasm32"))]
@@ -90,18 +145,16 @@ impl<App: Application> Adapter<App> {
         runtime: tokio::runtime::Runtime,
         event_config: EventStateConfig,
     ) -> Self {
-        Self {
-            tokio_runtime: runtime,
-            rendering_window: HashMap::new(),
-            window_states: HashMap::new(),
-            event_config,
-            app: Arc::new(app),
-        }
+        Self::with_runtime_and_event_config(RuntimeState::with_runtime(runtime), app, event_config)
     }
 
-    #[cfg(target_arch = "wasm32")]
-    fn wasm_new(app: App, event_config: EventStateConfig) -> Self {
+    fn with_runtime_and_event_config(
+        runtime: RuntimeState,
+        app: App,
+        event_config: EventStateConfig,
+    ) -> Self {
         Self {
+            runtime,
             rendering_window: HashMap::new(),
             window_states: HashMap::new(),
             event_config,
@@ -311,30 +364,11 @@ impl<App: Application> Adapter<App> {
 
 impl<App: Application> Adapter<App> {
     fn runtime_handle(&self) -> RuntimeHandle {
-        #[cfg(not(target_arch = "wasm32"))]
-        return RuntimeHandle::from_tokio(self.tokio_runtime.handle().clone());
-        #[cfg(target_arch = "wasm32")]
-        return RuntimeHandle;
+        self.runtime.handle()
     }
 
     fn abort_all_rendering_tasks(&mut self) {
-        #[cfg(not(target_arch = "wasm32"))]
-        self.tokio_runtime.block_on(async {
-            for handle in self.rendering_window.values() {
-                handle.abort();
-            }
-            for (_, handle) in self.rendering_window.drain() {
-                let _ = handle.join().await;
-            }
-        });
-
-        #[cfg(target_arch = "wasm32")]
-        {
-            for handle in self.rendering_window.values() {
-                handle.abort();
-            }
-            self.rendering_window.clear();
-        }
+        self.runtime.abort_all_tasks(&mut self.rendering_window);
     }
 
     fn remove_rendering_task(&mut self, window_id: WindowId) {

--- a/matcha-window/src/application.rs
+++ b/matcha-window/src/application.rs
@@ -1,4 +1,5 @@
 use crate::{
+    RuntimeHandle,
     adapter::{EventLoop, EventLoopProxy},
     event::{
         device_event::DeviceEvent,
@@ -8,26 +9,27 @@ use crate::{
     window::WindowId,
 };
 
-#[async_trait::async_trait]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 pub trait Application: Send + Sync + 'static {
     type Command: Send + 'static;
 
     // lifecycle methods
     fn init(
         &mut self,
-        runtime: &tokio::runtime::Handle,
+        runtime: &RuntimeHandle,
         proxy: Box<dyn EventLoopProxy<Self> + Send>,
         event_loop: &impl EventLoop,
     );
-    fn resumed(&self, runtime: &tokio::runtime::Handle, event_loop: &impl EventLoop);
-    fn create_surface(&self, runtime: &tokio::runtime::Handle, event_loop: &impl EventLoop);
-    fn destroy_surface(&self, runtime: &tokio::runtime::Handle, event_loop: &impl EventLoop);
-    fn suspended(&self, runtime: &tokio::runtime::Handle, event_loop: &impl EventLoop);
-    fn exiting(&self, runtime: &tokio::runtime::Handle, event_loop: &impl EventLoop);
+    fn resumed(&self, runtime: &RuntimeHandle, event_loop: &impl EventLoop);
+    fn create_surface(&self, runtime: &RuntimeHandle, event_loop: &impl EventLoop);
+    fn destroy_surface(&self, runtime: &RuntimeHandle, event_loop: &impl EventLoop);
+    fn suspended(&self, runtime: &RuntimeHandle, event_loop: &impl EventLoop);
+    fn exiting(&self, runtime: &RuntimeHandle, event_loop: &impl EventLoop);
 
     // rendering methods — no event_loop, spawnable in parallel
-    async fn render(&self, runtime: &tokio::runtime::Handle, window_id: WindowId);
-    fn request_redraw(&self, runtime: &tokio::runtime::Handle, window_id: WindowId) {
+    async fn render(&self, runtime: &RuntimeHandle, window_id: WindowId);
+    fn request_redraw(&self, runtime: &RuntimeHandle, window_id: WindowId) {
         let _ = runtime;
         let _ = window_id;
     }
@@ -35,27 +37,27 @@ pub trait Application: Send + Sync + 'static {
     // event methods
     fn window_event(
         &self,
-        runtime: &tokio::runtime::Handle,
+        runtime: &RuntimeHandle,
         event_loop: &impl EventLoop,
         window_id: WindowId,
         event: WindowEvent,
     );
     fn window_destroyed(
         &self,
-        runtime: &tokio::runtime::Handle,
+        runtime: &RuntimeHandle,
         event_loop: &impl EventLoop,
         window_id: WindowId,
     );
     fn device_event(
         &self,
-        runtime: &tokio::runtime::Handle,
+        runtime: &RuntimeHandle,
         event_loop: &impl EventLoop,
         window_id: WindowId,
         event: DeviceEvent,
     );
     fn ui_command(
         &self,
-        runtime: &tokio::runtime::Handle,
+        runtime: &RuntimeHandle,
         event_loop: &impl EventLoop,
         command: Self::Command,
     );
@@ -63,7 +65,7 @@ pub trait Application: Send + Sync + 'static {
     // Default Methods
     fn raw_device_event(
         &self,
-        runtime: &tokio::runtime::Handle,
+        runtime: &RuntimeHandle,
         event_loop: &impl EventLoop,
         raw_device_id: RawDeviceId,
         raw_event: RawDeviceEvent,
@@ -73,13 +75,13 @@ pub trait Application: Send + Sync + 'static {
         let _ = raw_device_id;
         let _ = raw_event;
     }
-    fn poll(&self, runtime: &tokio::runtime::Handle, event_loop: &impl EventLoop) {
+    fn poll(&self, runtime: &RuntimeHandle, event_loop: &impl EventLoop) {
         let _ = runtime;
         let _ = event_loop;
     }
     fn resume_time_reached(
         &self,
-        runtime: &tokio::runtime::Handle,
+        runtime: &RuntimeHandle,
         event_loop: &impl EventLoop,
         start: std::time::Instant,
         requested_resume: std::time::Instant,
@@ -91,7 +93,7 @@ pub trait Application: Send + Sync + 'static {
     }
     fn wait_cancelled(
         &self,
-        runtime: &tokio::runtime::Handle,
+        runtime: &RuntimeHandle,
         event_loop: &impl EventLoop,
         start: std::time::Instant,
         requested_resume: Option<std::time::Instant>,
@@ -101,11 +103,11 @@ pub trait Application: Send + Sync + 'static {
         let _ = start;
         let _ = requested_resume;
     }
-    fn about_to_wait(&self, runtime: &tokio::runtime::Handle, event_loop: &impl EventLoop) {
+    fn about_to_wait(&self, runtime: &RuntimeHandle, event_loop: &impl EventLoop) {
         let _ = runtime;
         let _ = event_loop;
     }
-    fn memory_warning(&self, runtime: &tokio::runtime::Handle, event_loop: &impl EventLoop) {
+    fn memory_warning(&self, runtime: &RuntimeHandle, event_loop: &impl EventLoop) {
         let _ = runtime;
         let _ = event_loop;
     }

--- a/matcha-window/src/application.rs
+++ b/matcha-window/src/application.rs
@@ -9,9 +9,20 @@ use crate::{
     window::WindowId,
 };
 
+/// Platform-specific supertrait: `Send + Sync` on native, plain `'static` on WASM.
+#[cfg(not(target_arch = "wasm32"))]
+pub trait ApplicationBounds: Send + Sync + 'static {}
+#[cfg(not(target_arch = "wasm32"))]
+impl<T: Send + Sync + 'static> ApplicationBounds for T {}
+
+#[cfg(target_arch = "wasm32")]
+pub trait ApplicationBounds: 'static {}
+#[cfg(target_arch = "wasm32")]
+impl<T: 'static> ApplicationBounds for T {}
+
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
-pub trait Application: Send + Sync + 'static {
+pub trait Application: ApplicationBounds {
     type Command: Send + 'static;
 
     // lifecycle methods
@@ -83,8 +94,8 @@ pub trait Application: Send + Sync + 'static {
         &self,
         runtime: &RuntimeHandle,
         event_loop: &impl EventLoop,
-        start: std::time::Instant,
-        requested_resume: std::time::Instant,
+        start: web_time::Instant,
+        requested_resume: web_time::Instant,
     ) {
         let _ = runtime;
         let _ = event_loop;
@@ -95,8 +106,8 @@ pub trait Application: Send + Sync + 'static {
         &self,
         runtime: &RuntimeHandle,
         event_loop: &impl EventLoop,
-        start: std::time::Instant,
-        requested_resume: Option<std::time::Instant>,
+        start: web_time::Instant,
+        requested_resume: Option<web_time::Instant>,
     ) {
         let _ = runtime;
         let _ = event_loop;

--- a/matcha-window/src/lib.rs
+++ b/matcha-window/src/lib.rs
@@ -4,7 +4,11 @@ compile_error!("feature \"winit\" and feature \"baseview\" cannot be enabled at 
 pub mod adapter;
 pub mod application;
 pub mod event;
+pub mod runtime_handle;
+pub mod task_handle;
 pub mod window;
+
+pub use runtime_handle::RuntimeHandle;
 
 #[cfg(feature = "winit")]
 pub(crate) mod winit_interface;

--- a/matcha-window/src/runtime_handle.rs
+++ b/matcha-window/src/runtime_handle.rs
@@ -1,0 +1,58 @@
+use crate::task_handle::TaskHandle;
+
+// ---------------------------------------------------------------------------
+// Native
+// ---------------------------------------------------------------------------
+
+#[cfg(not(target_arch = "wasm32"))]
+#[derive(Clone)]
+pub struct RuntimeHandle(tokio::runtime::Handle);
+
+#[cfg(not(target_arch = "wasm32"))]
+impl RuntimeHandle {
+    pub fn from_tokio(h: tokio::runtime::Handle) -> Self {
+        Self(h)
+    }
+
+    pub fn spawn<F, T>(&self, f: F) -> TaskHandle<T>
+    where
+        F: std::future::Future<Output = T> + Send + 'static,
+        T: Send + 'static,
+    {
+        TaskHandle(self.0.spawn(f))
+    }
+
+    pub fn enter(&self) -> tokio::runtime::EnterGuard<'_> {
+        self.0.enter()
+    }
+
+    pub fn tokio_handle(&self) -> &tokio::runtime::Handle {
+        &self.0
+    }
+}
+
+// ---------------------------------------------------------------------------
+// WASM
+// ---------------------------------------------------------------------------
+
+#[cfg(target_arch = "wasm32")]
+#[derive(Clone)]
+pub struct RuntimeHandle;
+
+#[cfg(target_arch = "wasm32")]
+impl RuntimeHandle {
+    pub fn spawn<F, T>(&self, f: F) -> TaskHandle<T>
+    where
+        F: std::future::Future<Output = T> + 'static,
+        T: 'static,
+    {
+        crate::task_handle::spawn_local_task(f)
+    }
+
+    pub fn enter(&self) -> WasmEnterGuard {
+        WasmEnterGuard
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+pub struct WasmEnterGuard;

--- a/matcha-window/src/task_handle.rs
+++ b/matcha-window/src/task_handle.rs
@@ -1,0 +1,77 @@
+// native
+#[cfg(not(target_arch = "wasm32"))]
+pub struct TaskHandle<T>(pub(crate) tokio::task::JoinHandle<T>);
+
+#[cfg(not(target_arch = "wasm32"))]
+impl<T> TaskHandle<T> {
+    pub fn is_finished(&self) -> bool {
+        self.0.is_finished()
+    }
+
+    pub fn abort(&self) {
+        self.0.abort();
+    }
+
+    pub async fn join(self) -> Option<T> {
+        self.0.await.ok()
+    }
+}
+
+// WASM
+//
+// Receiver<T> is !Sync (contains UnsafeCell), so we wrap it in parking_lot::Mutex
+// to make TaskHandle<T>: Send + Sync when T: Send — required because Application
+// stores TaskHandle<()> inside OnceLock which needs the payload to be Sync.
+#[cfg(target_arch = "wasm32")]
+pub struct TaskHandle<T> {
+    abort_handle: futures::future::AbortHandle,
+    finished: std::sync::Arc<std::sync::atomic::AtomicBool>,
+    receiver: parking_lot::Mutex<Option<futures::channel::oneshot::Receiver<T>>>,
+}
+
+#[cfg(target_arch = "wasm32")]
+impl<T> TaskHandle<T> {
+    pub fn is_finished(&self) -> bool {
+        self.finished
+            .load(std::sync::atomic::Ordering::Acquire)
+    }
+
+    pub fn abort(&self) {
+        self.abort_handle.abort();
+    }
+
+    pub async fn join(self) -> Option<T> {
+        let rx = self.receiver.into_inner();
+        match rx {
+            Some(rx) => rx.await.ok(),
+            None => None,
+        }
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+pub fn spawn_local_task<F, T>(f: F) -> TaskHandle<T>
+where
+    F: std::future::Future<Output = T> + 'static,
+    T: 'static,
+{
+    use futures::future::{AbortHandle, Abortable};
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    let (abort_handle, abort_reg) = AbortHandle::new_pair();
+    let finished = Arc::new(AtomicBool::new(false));
+    let finished_clone = finished.clone();
+    let (tx, rx) = futures::channel::oneshot::channel::<T>();
+    wasm_bindgen_futures::spawn_local(async move {
+        if let Ok(val) = Abortable::new(f, abort_reg).await {
+            let _ = tx.send(val);
+        }
+        finished_clone.store(true, Ordering::Release);
+    });
+    TaskHandle {
+        abort_handle,
+        finished,
+        receiver: parking_lot::Mutex::new(Some(rx)),
+    }
+}

--- a/matcha-window/src/window/window_config.rs
+++ b/matcha-window/src/window/window_config.rs
@@ -91,6 +91,10 @@ pub struct WindowConfig {
     pub resize_increments: Option<Size>,
     pub active: bool,
     pub surface_config: wgpu::SurfaceConfiguration,
+    /// HTML canvas element id to attach to on WASM.
+    /// If `None`, a new canvas is appended to the document body.
+    #[cfg(target_arch = "wasm32")]
+    pub canvas_id: Option<String>,
 }
 
 impl Default for WindowConfig {
@@ -121,6 +125,8 @@ impl Default for WindowConfig {
                 desired_maximum_frame_latency: 1,
                 alpha_mode: wgpu::CompositeAlphaMode::Auto,
             },
+            #[cfg(target_arch = "wasm32")]
+            canvas_id: None,
         }
     }
 }
@@ -239,6 +245,28 @@ impl WindowConfig {
         attr.preferred_theme = self.preferred_theme.map(Into::into);
         attr.resize_increments = self.resize_increments.map(Into::into);
         attr.active = self.active;
+
+        #[cfg(target_arch = "wasm32")]
+        {
+            use winit::platform::web::WindowAttributesExtWebSys;
+            if let Some(ref id) = self.canvas_id {
+                let canvas = web_sys::window()
+                    .and_then(|w| w.document())
+                    .and_then(|d| d.get_element_by_id(id))
+                    .and_then(|e| {
+                        use wasm_bindgen::JsCast;
+                        e.dyn_into::<web_sys::HtmlCanvasElement>().ok()
+                    });
+                if let Some(canvas) = canvas {
+                    attr = attr.with_canvas(Some(canvas));
+                } else {
+                    attr = attr.with_append(true);
+                }
+            } else {
+                attr = attr.with_append(true);
+            }
+        }
+
         attr
     }
 }

--- a/matcha-window/src/window/winit_window.rs
+++ b/matcha-window/src/window/winit_window.rs
@@ -292,6 +292,8 @@ impl WindowSurface {
             resize_increments: None,
             active: self.window.has_focus(),
             surface_config: config.clone(),
+            #[cfg(target_arch = "wasm32")]
+            canvas_id: None,
         }
     }
 

--- a/matcha-window/src/winit_interface.rs
+++ b/matcha-window/src/winit_interface.rs
@@ -30,7 +30,16 @@ pub(crate) fn run<App: Application>(
         adapter,
         event_loop_proxy,
     };
-    event_loop.run_app(&mut interface)
+
+    #[cfg(not(target_arch = "wasm32"))]
+    return event_loop.run_app(&mut interface);
+
+    #[cfg(target_arch = "wasm32")]
+    {
+        use winit::platform::web::EventLoopExtWebSys;
+        event_loop.spawn_app(interface);
+        Ok(())
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/renderer/Cargo.toml
+++ b/renderer/Cargo.toml
@@ -10,11 +10,14 @@ nalgebra.workspace = true
 bytemuck.workspace = true
 thiserror.workspace = true
 gpu-utils = { workspace = true }
-moka.workspace = true
 fxhash.workspace = true
 utils = { workspace = true }
 smallvec = { workspace = true }
 parking_lot.workspace = true
+dashmap = { workspace = true }
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+moka = { workspace = true }
 
 [lints]
 workspace = true

--- a/renderer/src/core_renderer.rs
+++ b/renderer/src/core_renderer.rs
@@ -6,9 +6,17 @@ use gpu_utils::{device_loss_recoverable::DeviceLossRecoverable, texture_atlas};
 use texture_atlas::RegionError;
 use thiserror::Error;
 
+#[cfg(not(target_arch = "wasm32"))]
 const WGSL_CULL: &str = include_str!("core_renderer/renderer_cull.wgsl");
+#[cfg(target_arch = "wasm32")]
+const WGSL_CULL: &str = include_str!("core_renderer/renderer_cull_web.wgsl");
+
 const WGSL_COMMAND: &str = include_str!("core_renderer/renderer_command.wgsl");
+
+#[cfg(not(target_arch = "wasm32"))]
 const WGSL_RENDER: &str = include_str!("core_renderer/renderer_render.wgsl");
+#[cfg(target_arch = "wasm32")]
+const WGSL_RENDER: &str = include_str!("core_renderer/renderer_render_web.wgsl");
 
 const PIPELINE_CACHE_SIZE: u64 = 3;
 const COMPUTE_WORKGROUP_SIZE: u32 = 64;
@@ -182,8 +190,11 @@ pub struct CoreRendererInner {
     // Pipelines
     culling_pipeline: wgpu::ComputePipeline,
     command_pipeline: wgpu::ComputePipeline,
-    render_pipeline:
-        moka::sync::Cache<wgpu::TextureFormat, Arc<wgpu::RenderPipeline>, fxhash::FxBuildHasher>, // key: surface format
+    render_pipeline: crate::pipeline_cache::PipelineCache<wgpu::TextureFormat, Arc<wgpu::RenderPipeline>>,
+
+    // Push-constant buffers (zero-size on native, UBO on WASM)
+    cull_pc_buffer: crate::push_constant_buffer::PcBuffer<CullingPushConstants>,
+    render_pc_buffer: crate::push_constant_buffer::PcBuffer<nalgebra::Matrix4<f32>>,
 
     // reusable buffers
     atomic_counter: wgpu::Buffer,
@@ -308,8 +319,16 @@ impl CoreRendererInner {
                 ],
             });
 
+        let cull_pc_layout =
+            crate::push_constant_buffer::PcBuffer::<CullingPushConstants>::bind_group_layout(
+                device,
+            );
+        let render_pc_layout = crate::push_constant_buffer::PcBuffer::<
+            nalgebra::Matrix4<f32>,
+        >::bind_group_layout(device);
+
         let (culling_pipeline_layout, culling_pipeline) =
-            Self::create_culling_pipeline(device, &data_bind_group_layout);
+            Self::create_culling_pipeline(device, &data_bind_group_layout, &cull_pc_layout);
 
         let (command_pipeline_layout, command_pipeline) =
             Self::create_command_pipeline(device, &data_bind_group_layout);
@@ -319,12 +338,16 @@ impl CoreRendererInner {
                 device,
                 &texture_bind_group_layout,
                 &data_bind_group_layout,
+                &render_pc_layout,
             );
         trace!("CoreRenderer::new: pipeline layouts created");
 
-        let render_pipeline = moka::sync::Cache::builder()
-            .max_capacity(PIPELINE_CACHE_SIZE)
-            .build_with_hasher(fxhash::FxBuildHasher::default());
+        let render_pipeline = crate::pipeline_cache::PipelineCache::new();
+
+        let cull_pc_buffer =
+            crate::push_constant_buffer::PcBuffer::new(device, &cull_pc_layout);
+        let render_pc_buffer =
+            crate::push_constant_buffer::PcBuffer::new(device, &render_pc_layout);
 
         // Create buffers
         let atomic_counter = device.create_buffer(&wgpu::BufferDescriptor {
@@ -360,6 +383,8 @@ impl CoreRendererInner {
             culling_pipeline,
             command_pipeline,
             render_pipeline,
+            cull_pc_buffer,
+            render_pc_buffer,
             atomic_counter,
             draw_command,
             draw_command_storage,
@@ -369,6 +394,7 @@ impl CoreRendererInner {
     fn create_culling_pipeline(
         device: &wgpu::Device,
         bind_group_layout: &wgpu::BindGroupLayout,
+        pc_layout: &wgpu::BindGroupLayout,
     ) -> (wgpu::PipelineLayout, wgpu::ComputePipeline) {
         trace!("CoreRenderer::create_culling_pipeline: creating pipeline");
         let module = device.create_shader_module(wgpu::ShaderModuleDescriptor {
@@ -376,13 +402,21 @@ impl CoreRendererInner {
             source: wgpu::ShaderSource::Wgsl(WGSL_CULL.into()),
         });
 
+        let pc_ranges =
+            crate::push_constant_buffer::PcBuffer::<CullingPushConstants>::push_constant_ranges(
+                wgpu::ShaderStages::COMPUTE,
+                std::mem::size_of::<CullingPushConstants>() as u32,
+            );
+
+        #[cfg(not(target_arch = "wasm32"))]
+        let bgl: &[&wgpu::BindGroupLayout] = &[bind_group_layout];
+        #[cfg(target_arch = "wasm32")]
+        let bgl: &[&wgpu::BindGroupLayout] = &[bind_group_layout, pc_layout];
+
         let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
             label: Some("Culling Pipeline Layout"),
-            bind_group_layouts: &[bind_group_layout],
-            push_constant_ranges: &[wgpu::PushConstantRange {
-                stages: wgpu::ShaderStages::COMPUTE,
-                range: 0..std::mem::size_of::<CullingPushConstants>() as u32,
-            }],
+            bind_group_layouts: bgl,
+            push_constant_ranges: &pc_ranges,
         });
 
         let pipeline = device.create_compute_pipeline(&wgpu::ComputePipelineDescriptor {
@@ -431,6 +465,7 @@ impl CoreRendererInner {
         device: &wgpu::Device,
         texture_bind_group_layout: &wgpu::BindGroupLayout,
         data_bind_group_layout: &wgpu::BindGroupLayout,
+        pc_layout: &wgpu::BindGroupLayout,
     ) -> (wgpu::PipelineLayout, wgpu::ShaderModule) {
         trace!("CoreRenderer::create_render_pipeline_layout: creating pipeline layout");
         let module = device.create_shader_module(wgpu::ShaderModuleDescriptor {
@@ -438,13 +473,24 @@ impl CoreRendererInner {
             source: wgpu::ShaderSource::Wgsl(WGSL_RENDER.into()),
         });
 
+        let pc_ranges = crate::push_constant_buffer::PcBuffer::<
+            nalgebra::Matrix4<f32>,
+        >::push_constant_ranges(
+            wgpu::ShaderStages::VERTEX | wgpu::ShaderStages::FRAGMENT,
+            std::mem::size_of::<nalgebra::Matrix4<f32>>() as u32,
+        );
+
+        #[cfg(not(target_arch = "wasm32"))]
+        let bgl: &[&wgpu::BindGroupLayout] =
+            &[texture_bind_group_layout, data_bind_group_layout];
+        #[cfg(target_arch = "wasm32")]
+        let bgl: &[&wgpu::BindGroupLayout] =
+            &[texture_bind_group_layout, data_bind_group_layout, pc_layout];
+
         let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
             label: Some("Render Pipeline Layout"),
-            bind_group_layouts: &[texture_bind_group_layout, data_bind_group_layout],
-            push_constant_ranges: &[wgpu::PushConstantRange {
-                stages: wgpu::ShaderStages::VERTEX | wgpu::ShaderStages::FRAGMENT,
-                range: 0..std::mem::size_of::<nalgebra::Matrix4<f32>>() as u32,
-            }],
+            bind_group_layouts: bgl,
+            push_constant_ranges: &pc_ranges,
         });
 
         (pipeline_layout, module)
@@ -552,7 +598,7 @@ impl CoreRendererInner {
         }
 
         // get or create render pipeline that matches given surface format
-        let render_pipeline = self.render_pipeline.get_with(surface_format, || {
+        let render_pipeline = self.render_pipeline.get_or_insert(surface_format, || {
             trace!("CoreRenderer::render: creating render pipeline for format {surface_format:?}");
             Arc::new(Self::create_render_pipeline(
                 device,
@@ -694,7 +740,7 @@ impl CoreRendererInner {
                 });
             culling_pass.set_pipeline(&self.culling_pipeline);
             culling_pass.set_bind_group(0, &data_bind_group, &[]);
-            culling_pass.set_push_constants(0, bytemuck::bytes_of(&cull_pc));
+            self.cull_pc_buffer.apply_to_compute_pass(queue, &mut culling_pass, 1, &cull_pc);
             culling_pass.dispatch_workgroups(
                 (instances.len() as u32).div_ceil(COMPUTE_WORKGROUP_SIZE),
                 1,
@@ -745,10 +791,13 @@ impl CoreRendererInner {
             render_pass.set_pipeline(render_pipeline.as_ref());
             render_pass.set_bind_group(0, &texture_bind_group, &[]);
             render_pass.set_bind_group(1, &data_bind_group, &[]);
-            render_pass.set_push_constants(
+            self.render_pc_buffer.apply_to_render_pass(
+                queue,
+                &mut render_pass,
+                2,
                 wgpu::ShaderStages::VERTEX | wgpu::ShaderStages::FRAGMENT,
                 0,
-                bytemuck::cast_slice(normalize_matrix.as_slice()),
+                &normalize_matrix,
             );
             render_pass.draw_indirect(&self.draw_command, 0);
         }

--- a/renderer/src/core_renderer/renderer_cull_web.wgsl
+++ b/renderer/src/core_renderer/renderer_cull_web.wgsl
@@ -1,0 +1,179 @@
+//// InstanceData describes a single textured instance uploaded from the host.
+//// Semantics:
+//// - `viewport_position`: 4x4 matrix that maps the unit quad vertices
+////   (defined as {[0, 0], [0, 1], [1, 1], [1, 0]} in this renderer)
+////   into the destination coordinate space prior to normalization. The shader
+////   multiplies this with the push-constant `normalize_matrix` to produce
+////   clip-space positions.
+//// - `atlas_page`: index of the texture array layer (page) inside the texture atlas.
+//// - `in_atlas_offset`: (x, y) offset of the sub-image inside the atlas page.
+////   Expected units: NORMALIZED UVs (0.0 .. 1.0) relative to the atlas page.
+////   If the atlas implementation provides pixel coordinates, the host MUST
+////   convert them to normalized coordinates before writing InstanceData into GPU memory.
+//// - `in_atlas_size`: (width, height) size of the sub-image. Expected as NORMALIZED
+////   values (0.0 .. 1.0). If atlas returns pixel sizes, normalize on the host side.
+//// - `stencil_index`: index+1 of the associated stencil in the stencil data array.
+////   0 indicates "no stencil". The shader uses `stencil_index - 1` to access the stencil.
+////
+//// NOTE: Keep WGSL-side layout (field order and explicit padding) compatible with the
+//// Rust `InstanceData` declaration. When changing fields, update both Rust and WGSL.
+struct InstanceData {
+    viewport_position: mat4x4<f32>,
+    atlas_page: u32,
+    _padding1: u32,
+    in_atlas_offset: vec2<f32>,
+    in_atlas_size: vec2<f32>,
+    stencil_index: u32,
+    _padding2: u32,
+};
+
+//// StencilData describes a stencil polygon used to mask instances.
+//// Semantics:
+//// - `viewport_position`: transform mapping the unit quad into stencil space.
+//// - `viewport_position_inverse_exists`: non-zero if `viewport_position` is invertible.
+//// - `viewport_position_inverse`: inverse matrix used by the vertex shader to compute
+////   stencil-space UV coordinates for masking.
+//// - `atlas_page`: index of the stencil atlas page (texture array layer).
+//// - `in_atlas_offset` / `in_atlas_size`: offset and size of the stencil image inside
+////   the atlas page. Expected to be NORMALIZED UVs (0.0 .. 1.0). If the atlas returns
+////   pixel coordinates, the host MUST normalize them before uploading to GPU.
+////
+//// NOTE: Maintain identical memory layout between this WGSL struct and the Rust
+//// `StencilData` declaration (including explicit padding fields). Update both
+//// definitions when changing sizes/types.
+struct StencilData {
+    viewport_position: mat4x4<f32>,
+    viewport_position_inverse_exists: u32,
+    _padding1: array<u32, 3>,
+    viewport_position_inverse: mat4x4<f32>,
+    atlas_page: u32,
+    _padding2: u32,
+    in_atlas_offset: vec2<f32>,
+    in_atlas_size: vec2<f32>,
+    _padding3: array<u32, 2>,
+};
+
+@group(0) @binding(0) var<storage, read> all_instances: array<InstanceData>;
+@group(0) @binding(1) var<storage, read> all_stencils: array<StencilData>;
+@group(0) @binding(2) var<storage, read_write> visible_instances: array<u32>;
+@group(0) @binding(3) var<storage, read_write> visible_instance_count: atomic<u32>;
+
+struct Pc {
+    normalize_matrix: mat4x4<f32>,
+    instance_count: u32,
+    _pad: vec3<u32>,
+};
+@group(1) @binding(0) var<uniform> pc: Pc;
+
+// vertices:
+// 0 - 3
+// |   |
+// 1 - 2
+const QUAD_VERTICES = array<vec4<f32>, 4>(
+    vec4<f32>(0.0, 0.0, 0.0, 1.0),
+    vec4<f32>(0.0, 1.0, 0.0, 1.0),
+    vec4<f32>(1.0, 1.0, 0.0, 1.0),
+    vec4<f32>(1.0, 0.0, 0.0, 1.0),
+);
+
+const CLIP_VERTICES = array<vec4<f32>, 4>(
+    vec4<f32>(-1.0,  1.0, 0.0, 1.0),
+    vec4<f32>(-1.0, -1.0, 0.0, 1.0),
+    vec4<f32>( 1.0, -1.0, 0.0, 1.0),
+    vec4<f32>( 1.0,  1.0, 0.0, 1.0),
+);
+
+@compute @workgroup_size(64)
+fn culling_main(@builtin(global_invocation_id) global_id: vec3<u32>) {
+    let instance_index = global_id.x;
+    if (instance_index >= pc.instance_count) {
+        return;
+    }
+    let instance = all_instances[instance_index];
+
+    let stencil_index_add_1 = instance.stencil_index;
+    let use_stencil = stencil_index_add_1 > 0u;
+    let stencil_index = max(stencil_index_add_1 - 1u, 0u);
+    let stencil = all_stencils[stencil_index];
+
+    // Visible conditions:
+    // 1. instance is within the viewport
+    // 2. (no stencil) or (stencil is within the viewport)
+    // 3. instance's polygon and stencil's polygon have overlap
+
+    var texture_position: array<vec4<f32>, 4>;
+    for (var i = 0u; i < 4u; i++) {
+        texture_position[i] = pc.normalize_matrix * instance.viewport_position * QUAD_VERTICES[i];
+    }
+
+    var stencil_position: array<vec4<f32>, 4>;
+    for (var i = 0u; i < 4u; i++) {
+        stencil_position[i] = pc.normalize_matrix * stencil.viewport_position * QUAD_VERTICES[i];
+    }
+
+    let texture_is_in_viewport = is_overlapping(texture_position, CLIP_VERTICES);
+    let stencil_is_in_viewport = is_overlapping(stencil_position, CLIP_VERTICES);
+    let texture_and_stencil_overlap = is_overlapping(texture_position, stencil_position);
+
+    let is_visible = texture_is_in_viewport && (
+        !use_stencil || (stencil_is_in_viewport && texture_and_stencil_overlap)
+    );
+
+    // if (is_visible) {
+    //     let visible_count = atomicAdd(&visible_instance_count, 1u);
+    //     visible_instances[visible_count] = instance_index;
+    // }
+
+    // currently show every instance for debugging purposes
+    // todo: implement proper visibility culling
+    if true {
+        let visible_count = atomicAdd(&visible_instance_count, 1u);
+        visible_instances[visible_count] = instance_index;
+    }
+}
+
+fn is_overlapping(
+    a: array<vec4<f32>, 4>,
+    b: array<vec4<f32>, 4>
+) -> bool {
+    var flag = false;
+    for (var i = 0u; i < 4u; i++) {
+        flag = flag || point_in_polygon(a[i], b);
+    }
+    for (var i = 0u; i < 4u; i++) {
+        flag = flag || point_in_polygon(b[i], a);
+    }
+    return flag;
+}
+
+fn cross_2d(a: vec2<f32>, b: vec2<f32>) -> f32 {
+    return a.x * b.y - a.y * b.x;
+}
+
+fn point_in_polygon(
+    point: vec4<f32>,
+    polygon: array<vec4<f32>, 4>
+) -> bool {
+    // use cross product to determine if the point is inside the polygon
+    let points = array<vec2<f32>, 4>(
+        polygon[0].xy - point.xy,
+        polygon[1].xy - point.xy,
+        polygon[2].xy - point.xy,
+        polygon[3].xy - point.xy,
+    );
+    let lines = array<vec2<f32>, 4>(
+        polygon[1].xy - polygon[0].xy,
+        polygon[2].xy - polygon[1].xy,
+        polygon[3].xy - polygon[2].xy,
+        polygon[0].xy - polygon[3].xy,
+    );
+
+    let signs = array<bool, 4>(
+        cross_2d(points[0], lines[0]) > 0.0,
+        cross_2d(points[1], lines[1]) > 0.0,
+        cross_2d(points[2], lines[2]) > 0.0,
+        cross_2d(points[3], lines[3]) > 0.0,
+    );
+
+    return signs[0] == signs[1] && signs[1] == signs[2] && signs[2] == signs[3];
+}

--- a/renderer/src/core_renderer/renderer_render_web.wgsl
+++ b/renderer/src/core_renderer/renderer_render_web.wgsl
@@ -76,7 +76,7 @@ struct VertexOutput {
 @group(1) @binding(1) var<storage, read> all_stencils: array<StencilData>;
 @group(1) @binding(2) var<storage, read> visible_instances: array<u32>;
 
-var<push_constant> normalize_matrix: mat4x4<f32>;
+@group(2) @binding(0) var<uniform> normalize_matrix: mat4x4<f32>;
 
 // vertices (y-axis is down, matches public UI unit-quad ordering):
 // 0 - 2

--- a/renderer/src/debug_renderer.rs
+++ b/renderer/src/debug_renderer.rs
@@ -1,3 +1,4 @@
+use crate::pipeline_cache::PipelineCache;
 use crate::render_node::RenderNode;
 use std::sync::Arc;
 
@@ -8,8 +9,7 @@ pub struct DebugRenderer {
     texture_bind_group_layout: wgpu::BindGroupLayout,
     pipeline_layout: wgpu::PipelineLayout,
     shader_module: wgpu::ShaderModule,
-    render_pipeline_cache:
-        moka::sync::Cache<wgpu::TextureFormat, Arc<wgpu::RenderPipeline>, fxhash::FxBuildHasher>,
+    render_pipeline_cache: PipelineCache<wgpu::TextureFormat, Arc<wgpu::RenderPipeline>>,
 }
 
 impl DebugRenderer {
@@ -63,9 +63,7 @@ impl DebugRenderer {
             push_constant_ranges: &[],
         });
 
-        let render_pipeline_cache = moka::sync::Cache::builder()
-            .max_capacity(4)
-            .build_with_hasher(fxhash::FxBuildHasher::default());
+        let render_pipeline_cache = PipelineCache::new();
 
         Self {
             texture_sampler,
@@ -174,7 +172,7 @@ fn fragment_main(in_ : VertexOutput) -> @location(0) vec4<f32> {{
             source: wgpu::ShaderSource::Wgsl(shader_source.into()),
         });
 
-        let pipeline = self.render_pipeline_cache.get_with(surface_format, || {
+        let pipeline = self.render_pipeline_cache.get_or_insert(surface_format, || {
             Arc::new(self.create_render_pipeline(device, &shader_module, surface_format))
         });
 

--- a/renderer/src/lib.rs
+++ b/renderer/src/lib.rs
@@ -1,5 +1,7 @@
 pub mod core_renderer;
 pub use core_renderer::CoreRenderer;
+pub mod pipeline_cache;
+pub mod push_constant_buffer;
 pub mod render_node;
 pub use render_node::RenderNode;
 

--- a/renderer/src/pipeline_cache.rs
+++ b/renderer/src/pipeline_cache.rs
@@ -1,0 +1,81 @@
+use std::hash::Hash;
+
+// ---------------------------------------------------------------------------
+// Native: backed by moka::sync::Cache
+// ---------------------------------------------------------------------------
+
+#[cfg(not(target_arch = "wasm32"))]
+pub struct PipelineCache<K, V> {
+    inner: moka::sync::Cache<K, V, fxhash::FxBuildHasher>,
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl<K, V> PipelineCache<K, V>
+where
+    K: Hash + Eq + Send + Sync + 'static,
+    V: Clone + Send + Sync + 'static,
+{
+    pub fn new() -> Self {
+        Self {
+            inner: moka::sync::Cache::builder()
+                .max_capacity(1024)
+                .build_with_hasher(fxhash::FxBuildHasher::default()),
+        }
+    }
+
+    pub fn get_or_insert<F: FnOnce() -> V>(&self, key: K, f: F) -> V {
+        self.inner.get_with(key, f)
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl<K, V> Default for PipelineCache<K, V>
+where
+    K: Hash + Eq + Send + Sync + 'static,
+    V: Clone + Send + Sync + 'static,
+{
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// WASM: backed by dashmap::DashMap (no thread-pool required)
+// ---------------------------------------------------------------------------
+
+#[cfg(target_arch = "wasm32")]
+pub struct PipelineCache<K, V> {
+    inner: dashmap::DashMap<K, V, fxhash::FxBuildHasher>,
+}
+
+#[cfg(target_arch = "wasm32")]
+impl<K, V> PipelineCache<K, V>
+where
+    K: Hash + Eq + 'static,
+    V: Clone + 'static,
+{
+    pub fn new() -> Self {
+        Self {
+            inner: dashmap::DashMap::with_hasher(fxhash::FxBuildHasher::default()),
+        }
+    }
+
+    pub fn get_or_insert<F: FnOnce() -> V>(&self, key: K, f: F) -> V {
+        self.inner
+            .entry(key)
+            .or_insert_with(f)
+            .value()
+            .clone()
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+impl<K, V> Default for PipelineCache<K, V>
+where
+    K: Hash + Eq + 'static,
+    V: Clone + 'static,
+{
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/renderer/src/push_constant_buffer.rs
+++ b/renderer/src/push_constant_buffer.rs
@@ -1,0 +1,136 @@
+use std::marker::PhantomData;
+
+#[cfg(not(target_arch = "wasm32"))]
+pub struct PcBuffer<T: bytemuck::Pod> {
+    _phantom: PhantomData<T>,
+}
+
+#[cfg(target_arch = "wasm32")]
+pub struct PcBuffer<T: bytemuck::Pod> {
+    buffer: wgpu::Buffer,
+    bind_group: wgpu::BindGroup,
+    _phantom: PhantomData<T>,
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl<T: bytemuck::Pod> PcBuffer<T> {
+    pub fn new(_device: &wgpu::Device, _bind_group_layout: &wgpu::BindGroupLayout) -> Self {
+        Self {
+            _phantom: PhantomData,
+        }
+    }
+
+    pub fn bind_group_layout(device: &wgpu::Device) -> wgpu::BindGroupLayout {
+        device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+            label: Some("PcBuffer (native, empty)"),
+            entries: &[],
+        })
+    }
+
+    pub fn push_constant_ranges(
+        shader_stages: wgpu::ShaderStages,
+        size: u32,
+    ) -> Vec<wgpu::PushConstantRange> {
+        vec![wgpu::PushConstantRange {
+            stages: shader_stages,
+            range: 0..size,
+        }]
+    }
+
+    pub fn apply_to_render_pass(
+        &self,
+        _queue: &wgpu::Queue,
+        pass: &mut wgpu::RenderPass<'_>,
+        _group: u32,
+        stages: wgpu::ShaderStages,
+        offset: u32,
+        data: &T,
+    ) {
+        pass.set_push_constants(stages, offset, bytemuck::bytes_of(data));
+    }
+
+    pub fn apply_to_compute_pass(
+        &self,
+        _queue: &wgpu::Queue,
+        pass: &mut wgpu::ComputePass<'_>,
+        _group: u32,
+        data: &T,
+    ) {
+        pass.set_push_constants(0, bytemuck::bytes_of(data));
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+impl<T: bytemuck::Pod> PcBuffer<T> {
+    pub fn new(device: &wgpu::Device, bind_group_layout: &wgpu::BindGroupLayout) -> Self {
+        let size = std::mem::size_of::<T>() as u64;
+        // Uniform buffers must be at least 16 bytes and aligned to 16 bytes.
+        let aligned_size = ((size.max(16) + 15) / 16) * 16;
+        let buffer = device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("PcBuffer uniform"),
+            size: aligned_size,
+            usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
+            mapped_at_creation: false,
+        });
+        let bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("PcBuffer bind group"),
+            layout: bind_group_layout,
+            entries: &[wgpu::BindGroupEntry {
+                binding: 0,
+                resource: buffer.as_entire_binding(),
+            }],
+        });
+        Self {
+            buffer,
+            bind_group,
+            _phantom: PhantomData,
+        }
+    }
+
+    pub fn bind_group_layout(device: &wgpu::Device) -> wgpu::BindGroupLayout {
+        device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+            label: Some("PcBuffer uniform layout"),
+            entries: &[wgpu::BindGroupLayoutEntry {
+                binding: 0,
+                visibility: wgpu::ShaderStages::VERTEX_FRAGMENT | wgpu::ShaderStages::COMPUTE,
+                ty: wgpu::BindingType::Buffer {
+                    ty: wgpu::BufferBindingType::Uniform,
+                    has_dynamic_offset: false,
+                    min_binding_size: None,
+                },
+                count: None,
+            }],
+        })
+    }
+
+    pub fn push_constant_ranges(
+        _shader_stages: wgpu::ShaderStages,
+        _size: u32,
+    ) -> Vec<wgpu::PushConstantRange> {
+        vec![]
+    }
+
+    pub fn apply_to_render_pass(
+        &self,
+        queue: &wgpu::Queue,
+        pass: &mut wgpu::RenderPass<'_>,
+        group: u32,
+        _stages: wgpu::ShaderStages,
+        _offset: u32,
+        data: &T,
+    ) {
+        queue.write_buffer(&self.buffer, 0, bytemuck::bytes_of(data));
+        pass.set_bind_group(group, &self.bind_group, &[]);
+    }
+
+    pub fn apply_to_compute_pass(
+        &self,
+        queue: &wgpu::Queue,
+        pass: &mut wgpu::ComputePass<'_>,
+        group: u32,
+        data: &T,
+    ) {
+        queue.write_buffer(&self.buffer, 0, bytemuck::bytes_of(data));
+        pass.set_bind_group(group, &self.bind_group, &[]);
+    }
+}

--- a/renderer/src/widgets_renderer/bezier_2d.rs
+++ b/renderer/src/widgets_renderer/bezier_2d.rs
@@ -1,13 +1,18 @@
+use crate::pipeline_cache::PipelineCache;
+use crate::push_constant_buffer::PcBuffer;
 use gpu_utils::texture_atlas;
 use std::sync::Arc;
 use utils::rwoption::RwOption;
 use wgpu::util::DeviceExt;
 
+#[cfg(not(target_arch = "wasm32"))]
+const WGSL_DRAW: &str = include_str!("./bezier_2d_draw.wgsl");
+#[cfg(target_arch = "wasm32")]
+const WGSL_DRAW: &str = include_str!("./bezier_2d_draw_web.wgsl");
+
 const WGSL_COMPUTE: &str = include_str!("./bezier_2d_compute.wgsl");
 const WGSL_COMMAND: &str = include_str!("./bezier_2d_command.wgsl");
-const WGSL_DRAW: &str = include_str!("./bezier_2d_draw.wgsl");
 
-const PIPELINE_CACHE_SIZE: u64 = 4;
 const COMPUTE_WORKGROUP_SIZE: u32 = 64;
 
 const VERTEX_DESC: wgpu::VertexBufferLayout = wgpu::VertexBufferLayout {
@@ -20,18 +25,6 @@ const VERTEX_DESC: wgpu::VertexBufferLayout = wgpu::VertexBufferLayout {
     }],
 };
 
-/*
-
-# in compute shader
-
-1. anchors:
-Vec<[f32; 2]> (len: n)
-
-2. vertices:
-[f32; 2] + Vec<[f32; 2]> + [f32; 2] (len: div + 2)
-
-*/
-
 #[repr(C)]
 #[derive(Copy, Clone, Debug, bytemuck::Pod, bytemuck::Zeroable)]
 struct BezierInfo {
@@ -39,6 +32,14 @@ struct BezierInfo {
     div: u32,
     width: f32,
     _padding: u32,
+}
+
+/// Combined affine_transform + color for the draw pass (native: split push constants; WASM: single UBO).
+#[repr(C)]
+#[derive(Copy, Clone, Debug, bytemuck::Pod, bytemuck::Zeroable)]
+struct DrawPushConstants {
+    affine_transform: nalgebra::Matrix4<f32>,
+    color: [f32; 4],
 }
 
 #[derive(Default)]
@@ -58,12 +59,13 @@ struct Bezier2dImpl {
     // Pipelines
     compute_pipeline: wgpu::ComputePipeline,
     command_pipeline: wgpu::ComputePipeline,
-    draw_pipeline:
-        moka::sync::Cache<wgpu::TextureFormat, Arc<wgpu::RenderPipeline>, fxhash::FxBuildHasher>,
+    draw_pipeline: PipelineCache<wgpu::TextureFormat, Arc<wgpu::RenderPipeline>>,
 
     // reusable resources
     draw_command_buffer: wgpu::Buffer,
     draw_command_storage: wgpu::Buffer,
+
+    draw_pc_buffer: PcBuffer<DrawPushConstants>,
 }
 
 pub struct TargetData {
@@ -135,11 +137,13 @@ impl Bezier2dImpl {
             make_compute_pipeline(device, &data_bind_group_layout);
         let (command_pipeline_layout, command_pipeline) =
             make_command_pipeline(device, &data_bind_group_layout);
-        let draw_pipeline_layout = make_draw_pipeline_layout(device);
 
-        let draw_pipeline = moka::sync::Cache::builder()
-            .max_capacity(PIPELINE_CACHE_SIZE)
-            .build_with_hasher(fxhash::FxBuildHasher::default());
+        let draw_pc_layout = PcBuffer::<DrawPushConstants>::bind_group_layout(device);
+        let draw_pipeline_layout = make_draw_pipeline_layout(device, &draw_pc_layout);
+
+        let draw_pc_buffer = PcBuffer::new(device, &draw_pc_layout);
+
+        let draw_pipeline = PipelineCache::new();
 
         let draw_command_buffer = device.create_buffer(&wgpu::BufferDescriptor {
             label: Some("bezier_2d_draw_command_buffer"),
@@ -165,6 +169,7 @@ impl Bezier2dImpl {
             draw_pipeline,
             draw_command_buffer,
             draw_command_storage,
+            draw_pc_buffer,
         })
     }
 }
@@ -172,6 +177,7 @@ impl Bezier2dImpl {
 impl Bezier2d {
     pub fn render(
         &self,
+        queue: &wgpu::Queue,
         command_encoder: &mut wgpu::CommandEncoder,
         TargetData { atlas_region }: TargetData,
         RenderData {
@@ -184,11 +190,9 @@ impl Bezier2d {
         device: &wgpu::Device,
     ) {
         if anchors.len() < 2 || div == 0 {
-            // Not enough anchors or divisions to compute Bezier curve
             return;
         }
 
-        // info
         let num_anchors = anchors.len() as u32;
         let compute_vertices = div + 1;
         let num_vertices = compute_vertices + 2;
@@ -196,12 +200,11 @@ impl Bezier2d {
         let target_format = atlas_region.format();
         let target_size = atlas_region.texture_size();
 
-        // Setup Bezier implementation
         let bezier_impl = self
             .inner
             .get_or_insert_with(|| Bezier2dImpl::setup(device));
 
-        let draw_pipeline = bezier_impl.draw_pipeline.get_with(target_format, || {
+        let draw_pipeline = bezier_impl.draw_pipeline.get_or_insert(target_format, || {
             Arc::new(make_draw_pipeline(
                 device,
                 target_format,
@@ -209,7 +212,6 @@ impl Bezier2d {
             ))
         });
 
-        // Create Buffers and Bind Groups
         let info = BezierInfo {
             num_anchors,
             div,
@@ -298,21 +300,41 @@ impl Bezier2d {
             return;
         };
 
-        // Render Pass
-        let affine_transform =
-            affine_transform([target_size[0] as f32, target_size[1] as f32], position);
+        let affine = affine_transform([target_size[0] as f32, target_size[1] as f32], position);
+        let draw_pc = DrawPushConstants {
+            affine_transform: affine,
+            color,
+        };
 
         render_pass.set_pipeline(&draw_pipeline);
-        render_pass.set_push_constants(
-            wgpu::ShaderStages::VERTEX,
-            0,
-            bytemuck::cast_slice(affine_transform.as_slice()),
-        );
-        render_pass.set_push_constants(
-            wgpu::ShaderStages::FRAGMENT,
-            std::mem::size_of::<nalgebra::Matrix4<f32>>() as u32,
-            bytemuck::cast_slice(&color),
-        );
+
+        // Native: two separate push constant ranges (VERTEX + FRAGMENT).
+        // WASM: single UBO at group 0 via PcBuffer.
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            render_pass.set_push_constants(
+                wgpu::ShaderStages::VERTEX,
+                0,
+                bytemuck::cast_slice(affine.as_slice()),
+            );
+            render_pass.set_push_constants(
+                wgpu::ShaderStages::FRAGMENT,
+                std::mem::size_of::<nalgebra::Matrix4<f32>>() as u32,
+                bytemuck::cast_slice(&color),
+            );
+        }
+        #[cfg(target_arch = "wasm32")]
+        {
+            bezier_impl.draw_pc_buffer.apply_to_render_pass(
+                queue,
+                &mut render_pass,
+                0,
+                wgpu::ShaderStages::VERTEX | wgpu::ShaderStages::FRAGMENT,
+                0,
+                &draw_pc,
+            );
+        }
+
         render_pass.set_vertex_buffer(0, vertex_buffer.slice(..));
         render_pass.draw_indirect(&bezier_impl.draw_command_buffer, 0);
     }
@@ -366,22 +388,39 @@ fn make_command_pipeline(
     (pipeline_layout, pipeline)
 }
 
-fn make_draw_pipeline_layout(device: &wgpu::Device) -> wgpu::PipelineLayout {
+fn make_draw_pipeline_layout(
+    device: &wgpu::Device,
+    pc_layout: &wgpu::BindGroupLayout,
+) -> wgpu::PipelineLayout {
+    let matrix_size = std::mem::size_of::<nalgebra::Matrix4<f32>>() as u32;
+    let color_size = std::mem::size_of::<[f32; 4]>() as u32;
+
+    #[cfg(not(target_arch = "wasm32"))]
+    let pc_ranges: &[wgpu::PushConstantRange] = &[
+        wgpu::PushConstantRange {
+            stages: wgpu::ShaderStages::VERTEX,
+            range: 0..matrix_size,
+        },
+        wgpu::PushConstantRange {
+            stages: wgpu::ShaderStages::FRAGMENT,
+            range: matrix_size..(matrix_size + color_size),
+        },
+    ];
+    #[cfg(not(target_arch = "wasm32"))]
+    let bgl: &[&wgpu::BindGroupLayout] = &[];
+
+    #[cfg(target_arch = "wasm32")]
+    let pc_ranges: &[wgpu::PushConstantRange] = &[];
+    #[cfg(target_arch = "wasm32")]
+    let bgl: &[&wgpu::BindGroupLayout] = &[pc_layout];
+
+    // suppress unused warning on native
+    let _ = pc_layout;
+
     device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
         label: Some("bezier_2d_draw_pipeline_layout"),
-        bind_group_layouts: &[],
-        push_constant_ranges: &[
-            wgpu::PushConstantRange {
-                stages: wgpu::ShaderStages::VERTEX,
-                range: 0..(std::mem::size_of::<nalgebra::Matrix4<f32>>() as u32),
-            },
-            wgpu::PushConstantRange {
-                stages: wgpu::ShaderStages::FRAGMENT,
-                range: (std::mem::size_of::<nalgebra::Matrix4<f32>>() as u32)
-                    ..(std::mem::size_of::<nalgebra::Matrix4<f32>>() as u32
-                        + std::mem::size_of::<[f32; 4]>() as u32),
-            },
-        ],
+        bind_group_layouts: bgl,
+        push_constant_ranges: pc_ranges,
     })
 }
 

--- a/renderer/src/widgets_renderer/bezier_2d_draw_web.wgsl
+++ b/renderer/src/widgets_renderer/bezier_2d_draw_web.wgsl
@@ -1,0 +1,22 @@
+struct PushConstants {
+    affine_transform: mat4x4<f32>,
+    color: vec4<f32>,
+};
+
+@group(0) @binding(0) var<uniform> pc: PushConstants;
+
+struct VertexOutput {
+    @builtin(position) position: vec4<f32>,
+};
+
+@vertex
+fn vs_main(@location(0) position: vec2<f32>) -> VertexOutput {
+    var out: VertexOutput;
+    out.position = pc.affine_transform * vec4<f32>(position, 0.0, 1.0);
+    return out;
+}
+
+@fragment
+fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
+    return pc.color;
+}

--- a/renderer/src/widgets_renderer/line_strip.rs
+++ b/renderer/src/widgets_renderer/line_strip.rs
@@ -1,8 +1,5 @@
-/*
-push constants:
-    [[f32; 4]; 4] // composed affine matrix
-*/
-
+use crate::pipeline_cache::PipelineCache;
+use crate::push_constant_buffer::PcBuffer;
 use crate::vertex::colored_vertex::ColorVertex;
 use utils::rwoption::RwOption;
 use wgpu::{PipelineCompilationOptions, util::DeviceExt};
@@ -12,30 +9,39 @@ pub struct LineStripColor {
     inner: RwOption<LineStripColorImpl>,
 }
 
-const PIPELINE_CACHE_SIZE: u64 = 4;
-
 struct LineStripColorImpl {
     pipeline_layout: wgpu::PipelineLayout,
-    pipeline: moka::sync::Cache<wgpu::TextureFormat, wgpu::RenderPipeline, fxhash::FxBuildHasher>,
+    pipeline: PipelineCache<wgpu::TextureFormat, wgpu::RenderPipeline>,
+    pc_buffer: PcBuffer<nalgebra::Matrix4<f32>>,
 }
 
 impl LineStripColorImpl {
     fn setup(device: &wgpu::Device) -> Self {
+        let pc_layout =
+            PcBuffer::<nalgebra::Matrix4<f32>>::bind_group_layout(device);
+        let pc_ranges = PcBuffer::<nalgebra::Matrix4<f32>>::push_constant_ranges(
+            wgpu::ShaderStages::VERTEX,
+            std::mem::size_of::<nalgebra::Matrix4<f32>>() as u32,
+        );
+
+        #[cfg(not(target_arch = "wasm32"))]
+        let bgl: &[&wgpu::BindGroupLayout] = &[];
+        #[cfg(target_arch = "wasm32")]
+        let bgl: &[&wgpu::BindGroupLayout] = &[&pc_layout];
+
         let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
             label: Some("line_strip_pipeline_layout"),
-            bind_group_layouts: &[],
-            push_constant_ranges: &[wgpu::PushConstantRange {
-                stages: wgpu::ShaderStages::VERTEX,
-                range: 0..(std::mem::size_of::<nalgebra::Matrix4<f32>>() as u32),
-            }],
+            bind_group_layouts: bgl,
+            push_constant_ranges: &pc_ranges,
         });
 
-        let pipeline = moka::sync::CacheBuilder::new(PIPELINE_CACHE_SIZE)
-            .build_with_hasher(fxhash::FxBuildHasher::default());
+        let pc_buffer = PcBuffer::new(device, &pc_layout);
+        let pipeline = PipelineCache::new();
 
         Self {
             pipeline_layout,
             pipeline,
+            pc_buffer,
         }
     }
 }
@@ -53,6 +59,7 @@ pub struct RenderData<'a> {
 impl LineStripColor {
     pub fn render(
         &self,
+        queue: &wgpu::Queue,
         render_pass: &mut wgpu::RenderPass<'_>,
         TargetData {
             target_size,
@@ -64,11 +71,12 @@ impl LineStripColor {
         let LineStripColorImpl {
             pipeline_layout,
             pipeline,
+            pc_buffer,
         } = &*self
             .inner
             .get_or_insert_with(|| LineStripColorImpl::setup(device));
 
-        let render_pipeline = pipeline.get_with(target_format, || {
+        let render_pipeline = pipeline.get_or_insert(target_format, || {
             make_pipeline(device, target_format, pipeline_layout)
         });
 
@@ -82,10 +90,13 @@ impl LineStripColor {
         });
 
         render_pass.set_pipeline(&render_pipeline);
-        render_pass.set_push_constants(
+        pc_buffer.apply_to_render_pass(
+            queue,
+            render_pass,
+            0,
             wgpu::ShaderStages::VERTEX,
             0,
-            bytemuck::cast_slice(view_port_affine_transform.as_slice()),
+            &view_port_affine_transform,
         );
         render_pass.set_vertex_buffer(0, vertex_buffer.slice(..));
         render_pass.draw(0..vertices.len() as u32, 0..1);
@@ -125,9 +136,14 @@ fn make_pipeline(
     target_format: wgpu::TextureFormat,
     pipeline_layout: &wgpu::PipelineLayout,
 ) -> wgpu::RenderPipeline {
+    #[cfg(not(target_arch = "wasm32"))]
+    let src = include_str!("line_strip.wgsl");
+    #[cfg(target_arch = "wasm32")]
+    let src = include_str!("line_strip_web.wgsl");
+
     let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
         label: Some("line_strip_shader"),
-        source: wgpu::ShaderSource::Wgsl(include_str!("line_strip.wgsl").into()),
+        source: wgpu::ShaderSource::Wgsl(src.into()),
     });
 
     device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {

--- a/renderer/src/widgets_renderer/line_strip_web.wgsl
+++ b/renderer/src/widgets_renderer/line_strip_web.wgsl
@@ -1,0 +1,25 @@
+struct VertexInput {
+    @location(0) position: vec3<f32>,
+    @location(1) color: vec4<f32>,
+};
+
+struct VertexOutput {
+    @builtin(position) clip_position: vec4<f32>,
+    @location(0) color: vec4<f32>,
+};
+
+@group(0) @binding(0) var<uniform> normalize_affine: mat4x4<f32>;
+
+@vertex
+fn vs_main(
+    model: VertexInput,
+) -> VertexOutput {
+    // let out: VertexOutput = VertexOutput(normalize_affine * model.position, model.color);
+    let out: VertexOutput = VertexOutput(normalize_affine * vec4(model.position, 1.0), model.color);
+    return out;
+}
+
+@fragment
+fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
+    return in.color;
+}

--- a/renderer/src/widgets_renderer/texture_color.rs
+++ b/renderer/src/widgets_renderer/texture_color.rs
@@ -1,18 +1,13 @@
+use crate::pipeline_cache::PipelineCache;
+use crate::push_constant_buffer::PcBuffer;
+use crate::vertex::uv_vertex::UvVertex;
 use utils::rwoption::RwOption;
 use wgpu::util::DeviceExt;
 
-use crate::vertex::uv_vertex::UvVertex;
 /* NOTE: This renderer assumes textures use top-origin UV coordinates (v = 0 at the top).
 UvVertex.tex_coords passed to this pipeline must have v = 0 at the top of the image.
 If your texture data uses bottom-origin coordinates, invert the v component before
 rendering (e.g. use 1.0 - v). */
-
-// API similar to line_strip.rs:
-// - TextureColor is Default and lazily initializes inner impl on first render
-// - Pipeline cached per target format using moka::sync::Cache
-// - Push constants used for affine matrix (vertex stage)
-
-const PIPELINE_CACHE_SIZE: u64 = 4;
 
 pub struct TextureColor {
     inner: RwOption<TextureColorImpl>,
@@ -21,8 +16,9 @@ pub struct TextureColor {
 struct TextureColorImpl {
     texture_bind_group_layout: wgpu::BindGroupLayout,
     pipeline_layout: wgpu::PipelineLayout,
-    pipeline: moka::sync::Cache<wgpu::TextureFormat, wgpu::RenderPipeline, fxhash::FxBuildHasher>,
+    pipeline: PipelineCache<wgpu::TextureFormat, wgpu::RenderPipeline>,
     texture_sampler: wgpu::Sampler,
+    pc_buffer: PcBuffer<nalgebra::Matrix4<f32>>,
 }
 
 impl TextureColorImpl {
@@ -50,17 +46,27 @@ impl TextureColorImpl {
                 ],
             });
 
+        let pc_layout = PcBuffer::<nalgebra::Matrix4<f32>>::bind_group_layout(device);
+        let pc_ranges = PcBuffer::<nalgebra::Matrix4<f32>>::push_constant_ranges(
+            wgpu::ShaderStages::VERTEX,
+            std::mem::size_of::<nalgebra::Matrix4<f32>>() as u32,
+        );
+
+        // On native: texture at group 0, no UBO group.
+        // On WASM: texture at group 0, UBO at group 1.
+        #[cfg(not(target_arch = "wasm32"))]
+        let bgl: &[&wgpu::BindGroupLayout] = &[&texture_bind_group_layout];
+        #[cfg(target_arch = "wasm32")]
+        let bgl: &[&wgpu::BindGroupLayout] = &[&texture_bind_group_layout, &pc_layout];
+
         let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
             label: Some("TextureColor: Pipeline Layout"),
-            bind_group_layouts: &[&texture_bind_group_layout],
-            push_constant_ranges: &[wgpu::PushConstantRange {
-                stages: wgpu::ShaderStages::VERTEX,
-                range: 0..(std::mem::size_of::<nalgebra::Matrix4<f32>>() as u32),
-            }],
+            bind_group_layouts: bgl,
+            push_constant_ranges: &pc_ranges,
         });
 
-        let pipeline = moka::sync::CacheBuilder::new(PIPELINE_CACHE_SIZE)
-            .build_with_hasher(fxhash::FxBuildHasher::default());
+        let pc_buffer = PcBuffer::new(device, &pc_layout);
+        let pipeline = PipelineCache::new();
 
         let texture_sampler = device.create_sampler(&wgpu::SamplerDescriptor {
             label: Some("TextureColor: Texture Sampler"),
@@ -78,6 +84,7 @@ impl TextureColorImpl {
             pipeline_layout,
             pipeline,
             texture_sampler,
+            pc_buffer,
         }
     }
 }
@@ -105,6 +112,7 @@ impl Default for TextureColor {
 impl TextureColor {
     pub fn render(
         &self,
+        queue: &wgpu::Queue,
         render_pass: &mut wgpu::RenderPass<'_>,
         TargetData {
             target_size,
@@ -122,31 +130,25 @@ impl TextureColor {
             .inner
             .get_or_insert_with(|| TextureColorImpl::setup(device));
 
-        // get or create pipeline for this target format
-        let render_pipeline = inner.pipeline.get_with(target_format, || {
+        let render_pipeline = inner.pipeline.get_or_insert(target_format, || {
             make_pipeline(device, target_format, &inner.pipeline_layout)
         });
 
-        // compute viewport affine transform
         let view_port_affine_transform =
             affine_transform([target_size[0] as f32, target_size[1] as f32], position);
 
-        // push constant (affine matrix) - must be set after pipeline is set
-        // create vertex buffer
         let vertex_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
             label: Some("texture_color_vertex_buffer"),
             contents: bytemuck::cast_slice(vertices),
             usage: wgpu::BufferUsages::VERTEX,
         });
 
-        // create index buffer
         let index_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
             label: Some("texture_color_index_buffer"),
             contents: bytemuck::cast_slice(indices),
             usage: wgpu::BufferUsages::INDEX,
         });
 
-        // texture bind group
         let texture_bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
             label: Some("TextureColor: Texture Bind Group"),
             layout: &inner.texture_bind_group_layout,
@@ -162,14 +164,16 @@ impl TextureColor {
             ],
         });
 
-        // set pipeline and resources
         render_pass.set_pipeline(&render_pipeline);
-        render_pass.set_push_constants(
+        render_pass.set_bind_group(0, &texture_bind_group, &[]);
+        inner.pc_buffer.apply_to_render_pass(
+            queue,
+            render_pass,
+            1,
             wgpu::ShaderStages::VERTEX,
             0,
-            bytemuck::cast_slice(view_port_affine_transform.as_slice()),
+            &view_port_affine_transform,
         );
-        render_pass.set_bind_group(0, &texture_bind_group, &[]);
         render_pass.set_vertex_buffer(0, vertex_buffer.slice(..));
         render_pass.set_index_buffer(index_buffer.slice(..), wgpu::IndexFormat::Uint16);
         render_pass.draw_indexed(0..indices.len() as u32, 0, 0..1);
@@ -181,9 +185,14 @@ fn make_pipeline(
     target_format: wgpu::TextureFormat,
     pipeline_layout: &wgpu::PipelineLayout,
 ) -> wgpu::RenderPipeline {
+    #[cfg(not(target_arch = "wasm32"))]
+    let src = include_str!("texture_color.wgsl");
+    #[cfg(target_arch = "wasm32")]
+    let src = include_str!("texture_color_web.wgsl");
+
     let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
         label: Some("texture_color_shader"),
-        source: wgpu::ShaderSource::Wgsl(include_str!("texture_color.wgsl").into()),
+        source: wgpu::ShaderSource::Wgsl(src.into()),
     });
 
     device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {

--- a/renderer/src/widgets_renderer/texture_color_web.wgsl
+++ b/renderer/src/widgets_renderer/texture_color_web.wgsl
@@ -1,0 +1,36 @@
+@group(1) @binding(0) var<uniform> normalize_affine: mat4x4<f32>;
+
+struct VertexInput {
+    @location(0) position: vec3<f32>,
+    @location(1) tex_coords: vec2<f32>,
+};
+
+struct VertexOutput {
+    @builtin(position) clip_position: vec4<f32>,
+    @location(0) tex_coords: vec2<f32>,
+};
+
+@group(0) @binding(0)
+var t_diffuse: texture_2d<f32>;
+@group(0) @binding(1)
+var s_diffuse: sampler;
+
+@vertex
+fn vs_main(
+    model: VertexInput,
+) -> VertexOutput {
+    var model4 = vec4<f32>(
+        model.position.x,
+        model.position.y,
+        model.position.z,
+        1.0,
+    );
+
+    let out: VertexOutput = VertexOutput(normalize_affine * model4, model.tex_coords);
+    return out;
+}
+
+@fragment
+fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
+    return textureSample(t_diffuse, s_diffuse, in.tex_coords);
+}

--- a/renderer/src/widgets_renderer/texture_copy.rs
+++ b/renderer/src/widgets_renderer/texture_copy.rs
@@ -1,3 +1,5 @@
+use crate::pipeline_cache::PipelineCache;
+use crate::push_constant_buffer::PcBuffer;
 use nalgebra::Matrix4;
 use utils::rwoption::RwOption;
 use wgpu::PipelineCompilationOptions;
@@ -14,9 +16,6 @@ push constants (as PushConstant struct):
     color_transformation: mat4x4<f32>
     color_offset: vec4<f32>
 */
-
-// vertex position will be calculated in the vertex shader (`vs_main`)
-// color will be calculated in the fragment shader (`fs_main`)
 
 #[repr(C)]
 #[derive(Copy, Clone, Debug, bytemuck::Pod, bytemuck::Zeroable)]
@@ -44,13 +43,12 @@ pub struct TextureCopy {
     inner: RwOption<TextureCopyImpl>,
 }
 
-const PIPELINE_CACHE_SIZE: u64 = 4;
-
 struct TextureCopyImpl {
     texture_bind_group_layout: wgpu::BindGroupLayout,
     texture_sampler: wgpu::Sampler,
     pipeline_layout: wgpu::PipelineLayout,
-    pipeline: moka::sync::Cache<wgpu::TextureFormat, wgpu::RenderPipeline, fxhash::FxBuildHasher>,
+    pipeline: PipelineCache<wgpu::TextureFormat, wgpu::RenderPipeline>,
+    pc_buffer: PcBuffer<PushConstant>,
 }
 
 impl TextureCopyImpl {
@@ -91,23 +89,34 @@ impl TextureCopyImpl {
             ..Default::default()
         });
 
+        let pc_layout = PcBuffer::<PushConstant>::bind_group_layout(device);
+        let pc_ranges = PcBuffer::<PushConstant>::push_constant_ranges(
+            wgpu::ShaderStages::VERTEX | wgpu::ShaderStages::FRAGMENT,
+            PUSH_CONSTANTS_SIZE,
+        );
+
+        // On native: texture at group 0, no UBO group.
+        // On WASM: texture at group 0, UBO at group 1.
+        #[cfg(not(target_arch = "wasm32"))]
+        let bgl: &[&wgpu::BindGroupLayout] = &[&texture_bind_group_layout];
+        #[cfg(target_arch = "wasm32")]
+        let bgl: &[&wgpu::BindGroupLayout] = &[&texture_bind_group_layout, &pc_layout];
+
         let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
             label: Some("texture_copy_pipeline_layout"),
-            bind_group_layouts: &[&texture_bind_group_layout],
-            push_constant_ranges: &[wgpu::PushConstantRange {
-                stages: wgpu::ShaderStages::VERTEX | wgpu::ShaderStages::FRAGMENT,
-                range: 0..PUSH_CONSTANTS_SIZE,
-            }],
+            bind_group_layouts: bgl,
+            push_constant_ranges: &pc_ranges,
         });
 
-        let pipeline = moka::sync::CacheBuilder::new(PIPELINE_CACHE_SIZE)
-            .build_with_hasher(fxhash::FxBuildHasher::default());
+        let pc_buffer = PcBuffer::new(device, &pc_layout);
+        let pipeline = PipelineCache::new();
 
         TextureCopyImpl {
             texture_bind_group_layout,
             texture_sampler,
             pipeline_layout,
             pipeline,
+            pc_buffer,
         }
     }
 }
@@ -128,6 +137,7 @@ pub struct RenderData<'a> {
 impl TextureCopy {
     pub fn render(
         &self,
+        queue: &wgpu::Queue,
         render_pass: &mut wgpu::RenderPass<'_>,
         TargetData {
             target_size,
@@ -147,13 +157,22 @@ impl TextureCopy {
             texture_sampler,
             pipeline_layout,
             pipeline,
+            pc_buffer,
         } = &*self
             .inner
             .get_or_insert_with(|| TextureCopyImpl::setup(device));
 
-        let render_pipeline = pipeline.get_with(target_format, || {
+        let render_pipeline = pipeline.get_or_insert(target_format, || {
             make_pipeline(device, target_format, pipeline_layout)
         });
+
+        let push_constants = PushConstant {
+            target_texture_size: [target_size[0] as f32, target_size[1] as f32],
+            source_texture_position_min,
+            source_texture_position_max,
+            color_transformation: color_transformation.unwrap_or_else(Matrix4::identity),
+            color_offset: color_offset.unwrap_or([0.0; 4]),
+        };
 
         render_pass.set_pipeline(&render_pipeline);
         render_pass.set_bind_group(
@@ -174,17 +193,13 @@ impl TextureCopy {
             }),
             &[],
         );
-        let push_constants = PushConstant {
-            target_texture_size: [target_size[0] as f32, target_size[1] as f32],
-            source_texture_position_min,
-            source_texture_position_max,
-            color_transformation: color_transformation.unwrap_or_else(Matrix4::identity),
-            color_offset: color_offset.unwrap_or([0.0; 4]),
-        };
-        render_pass.set_push_constants(
+        pc_buffer.apply_to_render_pass(
+            queue,
+            render_pass,
+            1,
             wgpu::ShaderStages::VERTEX | wgpu::ShaderStages::FRAGMENT,
             0,
-            bytemuck::cast_slice(&[push_constants]),
+            &push_constants,
         );
         render_pass.draw(0..4, 0..1);
     }
@@ -195,9 +210,14 @@ fn make_pipeline(
     target_format: wgpu::TextureFormat,
     pipeline_layout: &wgpu::PipelineLayout,
 ) -> wgpu::RenderPipeline {
+    #[cfg(not(target_arch = "wasm32"))]
+    let src = include_str!("texture_copy.wgsl");
+    #[cfg(target_arch = "wasm32")]
+    let src = include_str!("texture_copy_web.wgsl");
+
     let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
         label: Some("texture_copy_shader"),
-        source: wgpu::ShaderSource::Wgsl(include_str!("texture_copy.wgsl").into()),
+        source: wgpu::ShaderSource::Wgsl(src.into()),
     });
 
     device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {

--- a/renderer/src/widgets_renderer/texture_copy_web.wgsl
+++ b/renderer/src/widgets_renderer/texture_copy_web.wgsl
@@ -1,0 +1,65 @@
+// resource
+@group(0) @binding(0)
+var copy_source: texture_2d<f32>;
+@group(0) @binding(1)
+var texture_sampler: sampler;
+
+struct PushConstants {
+    color_transformation: mat4x4<f32>,
+    color_offset: vec4<f32>,
+    target_texture_size: vec2<f32>,
+    source_texture_position_min: vec2<f32>,
+    source_texture_position_max: vec2<f32>,
+};
+@group(1) @binding(0) var<uniform> pc: PushConstants;
+
+// vertex shader
+@vertex
+fn vs_main(
+    @builtin(vertex_index) vertex_index: u32
+) -> VertexOutput {
+    var pixel_positions: vec2<f32>;
+    var tex_coords: vec2<f32>;
+
+    // tex_coords are y-flipped
+
+    if vertex_index == 0 {
+        // top-left corner
+        pixel_positions = vec2<f32>(pc.source_texture_position_min.x, pc.source_texture_position_min.y);
+        tex_coords = vec2<f32>(0.0, 0.0);
+    } else if vertex_index == 1 {
+        // bottom-left corner
+        pixel_positions = vec2<f32>(pc.source_texture_position_min.x, pc.source_texture_position_max.y);
+        tex_coords = vec2<f32>(0.0, 1.0);
+    } else if vertex_index == 2 {
+        // top-right corner
+        pixel_positions = vec2<f32>(pc.source_texture_position_max.x, pc.source_texture_position_min.y);
+        tex_coords = vec2<f32>(1.0, 0.0);
+    } else {
+        // bottom-right corner
+        pixel_positions = vec2<f32>(pc.source_texture_position_max.x, pc.source_texture_position_max.y);
+        tex_coords = vec2<f32>(1.0, 1.0);
+    }
+
+    let position_y_down = (pixel_positions * 2.0) / pc.target_texture_size - vec2<f32>(1.0, 1.0);
+
+    // transform the y-axis
+    return VertexOutput(
+        vec4<f32>(position_y_down.x, -position_y_down.y, 0.0, 1.0),
+        tex_coords
+    );
+}
+
+struct VertexOutput {
+    @builtin(position) position: vec4<f32>,
+    @location(0) tex_coords: vec2<f32>,
+};
+
+// fragment shader
+@fragment
+fn fs_main(
+    @location(0) tex_coords: vec2<f32>
+) -> @location(0) vec4<f32> {
+    let source_color = textureSample(copy_source, texture_sampler, tex_coords);
+    return pc.color_transformation * source_color + pc.color_offset;
+}

--- a/renderer/src/widgets_renderer/vertex_color.rs
+++ b/renderer/src/widgets_renderer/vertex_color.rs
@@ -3,6 +3,8 @@ push constants:
     [[f32; 4]; 4] // composed affine matrix
 */
 
+use crate::pipeline_cache::PipelineCache;
+use crate::push_constant_buffer::PcBuffer;
 use crate::vertex::colored_vertex::ColorVertex;
 use utils::rwoption::RwOption;
 use wgpu::{PipelineCompilationOptions, util::DeviceExt};
@@ -11,30 +13,38 @@ pub struct VertexColor {
     inner: RwOption<VertexColorImpl>,
 }
 
-const PIPELINE_CACHE_SIZE: u64 = 4;
-
 struct VertexColorImpl {
     pipeline_layout: wgpu::PipelineLayout,
-    pipeline: moka::sync::Cache<wgpu::TextureFormat, wgpu::RenderPipeline, fxhash::FxBuildHasher>,
+    pipeline: PipelineCache<wgpu::TextureFormat, wgpu::RenderPipeline>,
+    pc_buffer: PcBuffer<nalgebra::Matrix4<f32>>,
 }
 
 impl VertexColorImpl {
     fn setup(device: &wgpu::Device) -> Self {
+        let pc_layout = PcBuffer::<nalgebra::Matrix4<f32>>::bind_group_layout(device);
+        let pc_ranges = PcBuffer::<nalgebra::Matrix4<f32>>::push_constant_ranges(
+            wgpu::ShaderStages::VERTEX,
+            std::mem::size_of::<nalgebra::Matrix4<f32>>() as u32,
+        );
+
+        #[cfg(not(target_arch = "wasm32"))]
+        let bgl: &[&wgpu::BindGroupLayout] = &[];
+        #[cfg(target_arch = "wasm32")]
+        let bgl: &[&wgpu::BindGroupLayout] = &[&pc_layout];
+
         let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
             label: Some("vertex_color_pipeline_layout"),
-            bind_group_layouts: &[],
-            push_constant_ranges: &[wgpu::PushConstantRange {
-                stages: wgpu::ShaderStages::VERTEX,
-                range: 0..(std::mem::size_of::<nalgebra::Matrix4<f32>>() as u32),
-            }],
+            bind_group_layouts: bgl,
+            push_constant_ranges: &pc_ranges,
         });
 
-        let pipeline = moka::sync::CacheBuilder::new(PIPELINE_CACHE_SIZE)
-            .build_with_hasher(fxhash::FxBuildHasher::default());
+        let pc_buffer = PcBuffer::new(device, &pc_layout);
+        let pipeline = PipelineCache::new();
 
         Self {
             pipeline_layout,
             pipeline,
+            pc_buffer,
         }
     }
 }
@@ -61,6 +71,7 @@ impl Default for VertexColor {
 impl VertexColor {
     pub fn render(
         &self,
+        queue: &wgpu::Queue,
         render_pass: &mut wgpu::RenderPass<'_>,
         TargetData {
             target_size,
@@ -76,16 +87,17 @@ impl VertexColor {
         let VertexColorImpl {
             pipeline_layout,
             pipeline,
+            pc_buffer,
         } = &*self
             .inner
             .get_or_insert_with(|| VertexColorImpl::setup(device));
 
-        let render_pipeline = pipeline.get_with(target_format, || {
+        let render_pipeline = pipeline.get_or_insert(target_format, || {
             make_pipeline(device, target_format, pipeline_layout)
         });
 
         let view_port_affine_transform =
-            viewport_transform([target_size[0] as f32, target_size[1] as f32]) * transform; // compose adaptive affine (style-provided) after viewport transform
+            viewport_transform([target_size[0] as f32, target_size[1] as f32]) * transform;
 
         let vertex_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
             label: Some("vertex_color_vertex_buffer"),
@@ -100,10 +112,13 @@ impl VertexColor {
         });
 
         render_pass.set_pipeline(&render_pipeline);
-        render_pass.set_push_constants(
+        pc_buffer.apply_to_render_pass(
+            queue,
+            render_pass,
+            0,
             wgpu::ShaderStages::VERTEX,
             0,
-            bytemuck::cast_slice(view_port_affine_transform.as_slice()),
+            &view_port_affine_transform,
         );
         render_pass.set_vertex_buffer(0, vertex_buffer.slice(..));
         render_pass.set_index_buffer(index_buffer.slice(..), wgpu::IndexFormat::Uint16);
@@ -128,9 +143,14 @@ fn make_pipeline(
     target_format: wgpu::TextureFormat,
     pipeline_layout: &wgpu::PipelineLayout,
 ) -> wgpu::RenderPipeline {
+    #[cfg(not(target_arch = "wasm32"))]
+    let src = include_str!("vertex_color.wgsl");
+    #[cfg(target_arch = "wasm32")]
+    let src = include_str!("vertex_color_web.wgsl");
+
     let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
         label: Some("vertex_color_shader"),
-        source: wgpu::ShaderSource::Wgsl(include_str!("vertex_color.wgsl").into()),
+        source: wgpu::ShaderSource::Wgsl(src.into()),
     });
 
     device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {

--- a/renderer/src/widgets_renderer/vertex_color_web.wgsl
+++ b/renderer/src/widgets_renderer/vertex_color_web.wgsl
@@ -1,0 +1,24 @@
+struct VertexInput {
+    @location(0) position: vec4<f32>,
+    @location(1) color: vec4<f32>,
+};
+
+struct VertexOutput {
+    @builtin(position) clip_position: vec4<f32>,
+    @location(0) color: vec4<f32>,
+};
+
+@group(0) @binding(0) var<uniform> normalize_affine: mat4x4<f32>;
+
+@vertex
+fn vs_main(
+    model: VertexInput,
+) -> VertexOutput {
+    let out: VertexOutput = VertexOutput(normalize_affine * model.position, model.color);
+    return out;
+}
+
+@fragment
+fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
+    return in.color;
+}

--- a/renderer/src/widgets_renderer/viewport_clear.rs
+++ b/renderer/src/widgets_renderer/viewport_clear.rs
@@ -1,6 +1,9 @@
 use utils::rwoption::RwOption;
 use wgpu::PipelineCompilationOptions;
 
+use crate::push_constant_buffer::PcBuffer;
+use crate::pipeline_cache::PipelineCache;
+
 /// Simple renderer that overwrites a scissored rectangle with a transparent color.
 /// API mirrors other widgets_renderer modules: create a small struct with an inner impl and a `render` method.
 #[derive(Default)]
@@ -8,52 +11,56 @@ pub struct ViewportClear {
     inner: RwOption<ViewportClearImpl>,
 }
 
-const PIPELINE_CACHE_SIZE: u64 = 4;
-
 #[repr(C)]
 #[derive(Copy, Clone, Debug, bytemuck::Pod, bytemuck::Zeroable)]
 struct PushConstant {
     color: [f32; 4],
 }
 
-const _: () = {
-    assert!(
-        wgpu::PUSH_CONSTANT_ALIGNMENT == 4,
-        "PushConstant alignment changed. check memory layout"
-    );
-};
-
-const PUSH_CONSTANTS_SIZE: u32 = std::mem::size_of::<PushConstant>() as u32;
-
 struct ViewportClearImpl {
     pipeline_layout: wgpu::PipelineLayout,
-    pipeline: moka::sync::Cache<wgpu::TextureFormat, wgpu::RenderPipeline, fxhash::FxBuildHasher>,
+    pipeline: PipelineCache<wgpu::TextureFormat, wgpu::RenderPipeline>,
+    pc_buffer: PcBuffer<PushConstant>,
 }
 
 impl ViewportClearImpl {
     fn setup(device: &wgpu::Device) -> Self {
+        let pc_layout = PcBuffer::<PushConstant>::bind_group_layout(device);
+        let pc_ranges = PcBuffer::<PushConstant>::push_constant_ranges(
+            wgpu::ShaderStages::FRAGMENT,
+            std::mem::size_of::<PushConstant>() as u32,
+        );
+
+        #[cfg(not(target_arch = "wasm32"))]
+        let bgl: &[&wgpu::BindGroupLayout] = &[];
+        #[cfg(target_arch = "wasm32")]
+        let bgl: &[&wgpu::BindGroupLayout] = &[&pc_layout];
+
         let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
             label: Some("viewport_clear_pipeline_layout"),
-            bind_group_layouts: &[],
-            push_constant_ranges: &[wgpu::PushConstantRange {
-                stages: wgpu::ShaderStages::FRAGMENT,
-                range: 0..PUSH_CONSTANTS_SIZE,
-            }],
+            bind_group_layouts: bgl,
+            push_constant_ranges: &pc_ranges,
         });
 
-        let pipeline = moka::sync::CacheBuilder::new(PIPELINE_CACHE_SIZE)
-            .build_with_hasher(fxhash::FxBuildHasher::default());
+        let pc_buffer = PcBuffer::new(device, &pc_layout);
+        let pipeline = PipelineCache::new();
 
         ViewportClearImpl {
             pipeline_layout,
             pipeline,
+            pc_buffer,
         }
     }
 }
 
 impl ViewportClear {
+    pub fn reset(&self) {
+        self.inner.take();
+    }
+
     pub fn render(
         &self,
+        queue: &wgpu::Queue,
         render_pass: &mut wgpu::RenderPass<'_>,
         target_format: wgpu::TextureFormat,
         device: &wgpu::Device,
@@ -62,21 +69,25 @@ impl ViewportClear {
         let ViewportClearImpl {
             pipeline_layout,
             pipeline,
+            pc_buffer,
         } = &*self
             .inner
             .get_or_insert_with(|| ViewportClearImpl::setup(device));
 
-        let pipeline = pipeline.get_with(target_format, || {
+        let pipeline = pipeline.get_or_insert(target_format, || {
             make_pipeline(device, target_format, pipeline_layout)
         });
 
         render_pass.set_pipeline(&pipeline);
 
-        let push_constants = PushConstant { color };
-        render_pass.set_push_constants(
+        let push_constant = PushConstant { color };
+        pc_buffer.apply_to_render_pass(
+            queue,
+            render_pass,
+            0,
             wgpu::ShaderStages::FRAGMENT,
             0,
-            bytemuck::cast_slice(&[push_constants]),
+            &push_constant,
         );
 
         render_pass.draw(0..4, 0..1);
@@ -88,9 +99,14 @@ fn make_pipeline(
     target_format: wgpu::TextureFormat,
     pipeline_layout: &wgpu::PipelineLayout,
 ) -> wgpu::RenderPipeline {
+    #[cfg(not(target_arch = "wasm32"))]
+    let src = include_str!("viewport_clear.wgsl");
+    #[cfg(target_arch = "wasm32")]
+    let src = include_str!("viewport_clear_web.wgsl");
+
     let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
         label: Some("viewport_clear_shader"),
-        source: wgpu::ShaderSource::Wgsl(include_str!("viewport_clear.wgsl").into()),
+        source: wgpu::ShaderSource::Wgsl(src.into()),
     });
 
     device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {

--- a/renderer/src/widgets_renderer/viewport_clear_web.wgsl
+++ b/renderer/src/widgets_renderer/viewport_clear_web.wgsl
@@ -1,0 +1,23 @@
+@vertex
+fn vs_main(@builtin(vertex_index) vertex_index: u32) -> @builtin(position) vec4<f32> {
+    // Triangle strip full-screen quad by vertex index
+    var positions = array<vec2<f32>, 4>(
+        vec2<f32>(-1.0, -1.0),
+        vec2<f32>(1.0, -1.0),
+        vec2<f32>(-1.0, 1.0),
+        vec2<f32>(1.0, 1.0),
+    );
+    let p = positions[vertex_index];
+    return vec4<f32>(p.x, p.y, 0.0, 1.0);
+}
+
+struct PushConstants {
+    color: vec4<f32>,
+};
+
+@group(0) @binding(0) var<uniform> pc: PushConstants;
+
+@fragment
+fn fs_main() -> @location(0) vec4<f32> {
+    return pc.color;
+}

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -2,6 +2,7 @@
 // ! Do not use these utilities at api level.
 
 pub mod back_prop_dirty;
+pub mod maybe_send_sync;
 pub mod benchmark;
 pub mod cache;
 pub mod process_unique_id;

--- a/utils/src/maybe_send_sync.rs
+++ b/utils/src/maybe_send_sync.rs
@@ -1,0 +1,11 @@
+/// On native (non-WASM), this is a supertrait requiring `Send + Sync`.
+/// On WASM, it is a no-op (WASM is single-threaded).
+#[cfg(not(target_arch = "wasm32"))]
+pub trait MaybeSendSync: Send + Sync {}
+#[cfg(not(target_arch = "wasm32"))]
+impl<T: Send + Sync> MaybeSendSync for T {}
+
+#[cfg(target_arch = "wasm32")]
+pub trait MaybeSendSync {}
+#[cfg(target_arch = "wasm32")]
+impl<T> MaybeSendSync for T {}


### PR DESCRIPTION
## Summary
This PR adds comprehensive WebAssembly (WASM) support to the codebase by introducing platform-specific abstractions for async runtime, push constants, and shader compilation. The changes enable the renderer and window system to work on both native (tokio-based) and WASM (futures-based) platforms.

## Key Changes

### Runtime & Task Abstractions
- **New `RuntimeHandle`**: Platform-agnostic async runtime interface
  - Native: wraps `tokio::runtime::Handle`
  - WASM: no-op implementation (single-threaded)
- **New `TaskHandle<T>`**: Platform-agnostic task handle
  - Native: wraps `tokio::task::JoinHandle`
  - WASM: uses `futures::channel::oneshot::Receiver` with `AbortHandle`
- Updated `Application` trait to use `RuntimeHandle` instead of `tokio::runtime::Handle`
- Added `#[async_trait(?Send)]` for WASM to allow non-Send futures

### Push Constants Abstraction
- **New `PcBuffer<T>`**: Unified push constant handling
  - Native: zero-cost abstraction using native push constants
  - WASM: converts push constants to uniform buffers (required by WebGPU spec)
- Automatically handles alignment and buffer management per platform
- Integrated into all affected renderers (bezier_2d, texture_copy, texture_color, line_strip, vertex_color, viewport_clear)

### Pipeline Cache Abstraction
- **New `PipelineCache<K, V>`**: Unified pipeline caching
  - Native: uses `moka::sync::Cache` with thread-safe hasher
  - WASM: uses `dashmap::DashMap` (no thread-pool required)
- Replaces direct `moka::sync::Cache` usage across renderers
- Removed `PIPELINE_CACHE_SIZE` constants (now uses sensible defaults)

### Shader Variants
- Added WASM-specific shader files for all affected renderers:
  - `renderer_cull_web.wgsl`, `renderer_render_web.wgsl`
  - `bezier_2d_draw_web.wgsl`, `texture_copy_web.wgsl`, `texture_color_web.wgsl`
  - `line_strip_web.wgsl`, `vertex_color_web.wgsl`, `viewport_clear_web.wgsl`
  - `viewport_clear_web.wgsl` (gpu-utils)
- Shaders use uniform buffers instead of push constants for WASM
- Conditional compilation selects appropriate shader at build time

### Platform-Specific Trait Bounds
- **New `ApplicationBounds`**: Conditional `Send + Sync` requirement
  - Native: requires `Send + Sync + 'static`
  - WASM: only requires `'static`
- **New `MaybeSendSync`**: Utility trait for conditional bounds in widget code
- Updated closure types in polygon, button, and size modules to be platform-aware

### Window & Adapter Changes
- `Adapter` now conditionally stores `tokio_runtime` (native only)
- Added `wasm_new()` constructor for WASM initialization
- Updated `init()`, `resumed()`, `create_surface()` to use `RuntimeHandle`
- Added `canvas_id` field to `WindowConfig` for WASM canvas attachment
- Conditional `event_loop.run_app()` handling for WASM

### Dependencies
- Removed `tokio` multi-threading feature (`rt-multi-thread`)
- Added WASM-specific dependencies: `web-time`, `futures`, `parking_lot`
- Removed `moka` from renderer (now conditional via abstraction)
- Added `dashmap` for WASM pipeline caching

## Notable Implementation Details

1. **Push Constants on WASM**: WebGPU doesn't support push constants, so `PcBuffer` transparently converts them to uniform buffers with proper alignment (16-byte minimum, 16-byte aligned).

2. **Shader Compilation**: Conditional `include_str!()` macros

https://claude.ai/code/session_015rSjn8QCcqqonVWfWwYqyT