### PR TITLE
Refactor culling pipeline into swappable compute stages

### DIFF
--- a/renderer/src/core_renderer.rs
+++ b/renderer/src/core_renderer.rs
@@ -6,12 +6,15 @@ use gpu_utils::texture_atlas;
 use texture_atlas::RegionError;
 use thiserror::Error;
 
-const WGSL_CULL: &str = include_str!("core_renderer/renderer_cull.wgsl");
-const WGSL_COMMAND: &str = include_str!("core_renderer/renderer_command.wgsl");
+mod stages;
+use stages::{
+    BlellochPrefixSumStage, CommandStage, ComputeStage, ScatterStage, StageParams,
+    VisibilityStage,
+};
+
 const WGSL_RENDER: &str = include_str!("core_renderer/renderer_render.wgsl");
 
 const PIPELINE_CACHE_SIZE: u64 = 3;
-const COMPUTE_WORKGROUP_SIZE: u32 = 64;
 
 // PERF NOTE:
 // - BindGroup/Buffer の再利用・リング化を検討（毎フレームの生成/全量 write を抑制）
@@ -102,14 +105,6 @@ const _: () = {
     assert!(std::mem::size_of::<StencilData>() == 176);
     assert!(std::mem::size_of::<RenderPushConstants>() == 80);
 };
-
-#[repr(C)]
-#[derive(Copy, Clone, Debug, bytemuck::Pod, bytemuck::Zeroable)]
-struct CullingPushConstants {
-    normalize_matrix: nalgebra::Matrix4<f32>,
-    instance_count: u32,
-    _pad: [u32; 3],
-}
 
 /// Half a texel, in normalized UV units, for each atlas. Used by the render
 /// shader to inset the UV clamp bounds so that sampling at the very edge of
@@ -210,14 +205,15 @@ pub struct CoreRendererInner {
     data_bind_group_layout: wgpu::BindGroupLayout,
 
     // Pipeline Layouts
-    culling_pipeline_layout: wgpu::PipelineLayout,
-    command_pipeline_layout: wgpu::PipelineLayout,
     render_pipeline_layout: wgpu::PipelineLayout,
     render_pipeline_shader_module: wgpu::ShaderModule,
 
+    // Compute stages of the compaction pipeline (visibility -> prefix sum ->
+    // scatter -> command), run in order. Each stage is an interchangeable
+    // `ComputeStage` implementation; see `stages.rs`.
+    compaction_stages: Vec<Box<dyn ComputeStage>>,
+
     // Pipelines
-    culling_pipeline: wgpu::ComputePipeline,
-    command_pipeline: wgpu::ComputePipeline,
     render_pipeline:
         crate::pipeline_cache::PipelineCache<wgpu::TextureFormat, Arc<wgpu::RenderPipeline>>, // key: surface format
 
@@ -225,6 +221,99 @@ pub struct CoreRendererInner {
     atomic_counter: wgpu::Buffer,
     draw_command: wgpu::Buffer,
     draw_command_storage: wgpu::Buffer,
+}
+
+/// Bind group layout for the data buffers shared by every compute stage and
+/// the render pass. Bindings 0-4 are also visible to the render shaders;
+/// bindings 5-6 are compute-only intermediates of the order-preserving
+/// compaction (see `stages.rs`).
+fn create_data_bind_group_layout(device: &wgpu::Device) -> wgpu::BindGroupLayout {
+    device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+        label: Some("ObjectRenderer Data Bind Group Layout"),
+        entries: &[
+            // All Instances Buffer
+            wgpu::BindGroupLayoutEntry {
+                binding: 0,
+                visibility: wgpu::ShaderStages::COMPUTE | wgpu::ShaderStages::VERTEX,
+                ty: wgpu::BindingType::Buffer {
+                    ty: wgpu::BufferBindingType::Storage { read_only: true },
+                    has_dynamic_offset: false,
+                    min_binding_size: None,
+                },
+                count: None,
+            },
+            // All Stencils Buffer
+            wgpu::BindGroupLayoutEntry {
+                binding: 1,
+                visibility: wgpu::ShaderStages::COMPUTE
+                    | wgpu::ShaderStages::FRAGMENT
+                    | wgpu::ShaderStages::VERTEX,
+                ty: wgpu::BindingType::Buffer {
+                    ty: wgpu::BufferBindingType::Storage { read_only: true },
+                    has_dynamic_offset: false,
+                    min_binding_size: None,
+                },
+                count: None,
+            },
+            // Visible Instances Buffer (compacted, submission order)
+            wgpu::BindGroupLayoutEntry {
+                binding: 2,
+                visibility: wgpu::ShaderStages::COMPUTE | wgpu::ShaderStages::VERTEX,
+                ty: wgpu::BindingType::Buffer {
+                    ty: wgpu::BufferBindingType::Storage { read_only: false },
+                    has_dynamic_offset: false,
+                    min_binding_size: None,
+                },
+                count: None,
+            },
+            // Atomic Counter (visible instance count)
+            wgpu::BindGroupLayoutEntry {
+                binding: 3,
+                visibility: wgpu::ShaderStages::COMPUTE,
+                ty: wgpu::BindingType::Buffer {
+                    ty: wgpu::BufferBindingType::Storage { read_only: false },
+                    has_dynamic_offset: false,
+                    min_binding_size: None,
+                },
+                count: None,
+            },
+            // command buffer (indirect draw args)
+            wgpu::BindGroupLayoutEntry {
+                binding: 4,
+                visibility: wgpu::ShaderStages::COMPUTE,
+                ty: wgpu::BindingType::Buffer {
+                    ty: wgpu::BufferBindingType::Storage { read_only: false },
+                    has_dynamic_offset: false,
+                    min_binding_size: None,
+                },
+                count: None,
+            },
+            // Visibility flags (0/1 per instance; written by the visibility
+            // stage, consumed by the prefix-sum and scatter stages)
+            wgpu::BindGroupLayoutEntry {
+                binding: 5,
+                visibility: wgpu::ShaderStages::COMPUTE,
+                ty: wgpu::BindingType::Buffer {
+                    ty: wgpu::BufferBindingType::Storage { read_only: false },
+                    has_dynamic_offset: false,
+                    min_binding_size: None,
+                },
+                count: None,
+            },
+            // Scan offsets (exclusive prefix sum of the visibility flags;
+            // written by the prefix-sum stage, consumed by the scatter stage)
+            wgpu::BindGroupLayoutEntry {
+                binding: 6,
+                visibility: wgpu::ShaderStages::COMPUTE,
+                ty: wgpu::BindingType::Buffer {
+                    ty: wgpu::BufferBindingType::Storage { read_only: false },
+                    has_dynamic_offset: false,
+                    min_binding_size: None,
+                },
+                count: None,
+            },
+        ],
+    })
 }
 
 impl CoreRendererInner {
@@ -279,76 +368,16 @@ impl CoreRendererInner {
                 ],
             });
 
-        // Culling Pipeline
-        let data_bind_group_layout =
-            device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
-                label: Some("Culling Bind Group Layout"),
-                entries: &[
-                    // All Instances Buffer
-                    wgpu::BindGroupLayoutEntry {
-                        binding: 0,
-                        visibility: wgpu::ShaderStages::COMPUTE | wgpu::ShaderStages::VERTEX,
-                        ty: wgpu::BindingType::Buffer {
-                            ty: wgpu::BufferBindingType::Storage { read_only: true },
-                            has_dynamic_offset: false,
-                            min_binding_size: None,
-                        },
-                        count: None,
-                    },
-                    // All Stencils Buffer
-                    wgpu::BindGroupLayoutEntry {
-                        binding: 1,
-                        visibility: wgpu::ShaderStages::COMPUTE
-                            | wgpu::ShaderStages::FRAGMENT
-                            | wgpu::ShaderStages::VERTEX,
-                        ty: wgpu::BindingType::Buffer {
-                            ty: wgpu::BufferBindingType::Storage { read_only: true },
-                            has_dynamic_offset: false,
-                            min_binding_size: None,
-                        },
-                        count: None,
-                    },
-                    // Visible Instances Buffer
-                    wgpu::BindGroupLayoutEntry {
-                        binding: 2,
-                        visibility: wgpu::ShaderStages::COMPUTE | wgpu::ShaderStages::VERTEX,
-                        ty: wgpu::BindingType::Buffer {
-                            ty: wgpu::BufferBindingType::Storage { read_only: false },
-                            has_dynamic_offset: false,
-                            min_binding_size: None,
-                        },
-                        count: None,
-                    },
-                    // Atomic Counter
-                    wgpu::BindGroupLayoutEntry {
-                        binding: 3,
-                        visibility: wgpu::ShaderStages::COMPUTE,
-                        ty: wgpu::BindingType::Buffer {
-                            ty: wgpu::BufferBindingType::Storage { read_only: false },
-                            has_dynamic_offset: false,
-                            min_binding_size: None,
-                        },
-                        count: None,
-                    },
-                    // command buffer
-                    wgpu::BindGroupLayoutEntry {
-                        binding: 4,
-                        visibility: wgpu::ShaderStages::COMPUTE,
-                        ty: wgpu::BindingType::Buffer {
-                            ty: wgpu::BufferBindingType::Storage { read_only: false },
-                            has_dynamic_offset: false,
-                            min_binding_size: None,
-                        },
-                        count: None,
-                    },
-                ],
-            });
+        let data_bind_group_layout = create_data_bind_group_layout(device);
 
-        let (culling_pipeline_layout, culling_pipeline) =
-            Self::create_culling_pipeline(device, &data_bind_group_layout);
-
-        let (command_pipeline_layout, command_pipeline) =
-            Self::create_command_pipeline(device, &data_bind_group_layout);
+        let compaction_stages: Vec<Box<dyn ComputeStage>> = vec![
+            Box::new(VisibilityStage::new(device, &data_bind_group_layout)),
+            // Swap the scan algorithm by constructing a different stage here
+            // (e.g. `SingleThreadPrefixSumStage` as the naive reference).
+            Box::new(BlellochPrefixSumStage::new(device, &data_bind_group_layout)),
+            Box::new(ScatterStage::new(device, &data_bind_group_layout)),
+            Box::new(CommandStage::new(device, &data_bind_group_layout)),
+        ];
 
         let (render_pipeline_layout, render_pipeline_shader_module) =
             Self::create_render_pipeline_layout(
@@ -387,75 +416,14 @@ impl CoreRendererInner {
             texture_sampler,
             texture_bind_group_layout,
             data_bind_group_layout,
-            culling_pipeline_layout,
-            command_pipeline_layout,
             render_pipeline_layout,
             render_pipeline_shader_module,
-            culling_pipeline,
-            command_pipeline,
+            compaction_stages,
             render_pipeline,
             atomic_counter,
             draw_command,
             draw_command_storage,
         }
-    }
-
-    fn create_culling_pipeline(
-        device: &wgpu::Device,
-        bind_group_layout: &wgpu::BindGroupLayout,
-    ) -> (wgpu::PipelineLayout, wgpu::ComputePipeline) {
-        trace!("CoreRenderer::create_culling_pipeline: creating pipeline");
-        let module = device.create_shader_module(wgpu::ShaderModuleDescriptor {
-            label: Some("Culling Shader"),
-            source: wgpu::ShaderSource::Wgsl(WGSL_CULL.into()),
-        });
-
-        let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
-            label: Some("Culling Pipeline Layout"),
-            bind_group_layouts: &[Some(bind_group_layout)],
-            immediate_size: std::mem::size_of::<CullingPushConstants>() as u32,
-        });
-
-        let pipeline = device.create_compute_pipeline(&wgpu::ComputePipelineDescriptor {
-            label: Some("Culling Pipeline"),
-            layout: Some(&pipeline_layout),
-            module: &module,
-            entry_point: Some("culling_main"),
-            compilation_options: Default::default(),
-            cache: None,
-        });
-        trace!("CoreRenderer::create_culling_pipeline: pipeline ready");
-
-        (pipeline_layout, pipeline)
-    }
-
-    fn create_command_pipeline(
-        device: &wgpu::Device,
-        bind_group_layout: &wgpu::BindGroupLayout,
-    ) -> (wgpu::PipelineLayout, wgpu::ComputePipeline) {
-        trace!("CoreRenderer::create_command_pipeline: creating pipeline");
-        let module = device.create_shader_module(wgpu::ShaderModuleDescriptor {
-            label: Some("Command Shader"),
-            source: wgpu::ShaderSource::Wgsl(WGSL_COMMAND.into()),
-        });
-
-        let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
-            label: Some("Command Pipeline Layout"),
-            bind_group_layouts: &[Some(bind_group_layout)],
-            immediate_size: 0,
-        });
-
-        let pipeline = device.create_compute_pipeline(&wgpu::ComputePipelineDescriptor {
-            label: Some("Command Pipeline"),
-            layout: Some(&pipeline_layout),
-            module: &module,
-            entry_point: Some("command_main"),
-            compilation_options: Default::default(),
-            cache: None,
-        });
-        trace!("CoreRenderer::create_command_pipeline: pipeline ready");
-
-        (pipeline_layout, pipeline)
     }
 
     fn create_render_pipeline_layout(
@@ -684,6 +652,20 @@ impl CoreRendererInner {
             mapped_at_creation: false,
         });
 
+        let visibility_flags_buffer = device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("ObjectRenderer Visibility Flags Buffer"),
+            size: (std::mem::size_of::<u32>() * instances.len()) as u64,
+            usage: wgpu::BufferUsages::STORAGE,
+            mapped_at_creation: false,
+        });
+
+        let scan_offsets_buffer = device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("ObjectRenderer Scan Offsets Buffer"),
+            size: (std::mem::size_of::<u32>() * instances.len()) as u64,
+            usage: wgpu::BufferUsages::STORAGE,
+            mapped_at_creation: false,
+        });
+
         // Create bind groups
         let texture_bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
             label: Some("ObjectRenderer Texture Bind Group"),
@@ -740,6 +722,14 @@ impl CoreRendererInner {
                     binding: 4,
                     resource: self.draw_command_storage.as_entire_binding(),
                 },
+                wgpu::BindGroupEntry {
+                    binding: 5,
+                    resource: visibility_flags_buffer.as_entire_binding(),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 6,
+                    resource: scan_offsets_buffer.as_entire_binding(),
+                },
             ],
         });
 
@@ -779,10 +769,9 @@ impl CoreRendererInner {
         trace!("CoreRenderer::render: command encoder created");
 
         let normalize_matrix = make_normalize_matrix(destination_size);
-        let cull_pc = CullingPushConstants {
+        let stage_params = StageParams {
             normalize_matrix,
             instance_count: instances.len() as u32,
-            _pad: [0; 3],
         };
         let texture_atlas_size = texture_atlas.size();
         let stencil_atlas_size = stencil_atlas.size();
@@ -798,36 +787,13 @@ impl CoreRendererInner {
             ],
         };
 
-        // culling compute pass
-        {
-            let mut culling_pass =
-                command_encoder.begin_compute_pass(&wgpu::ComputePassDescriptor {
-                    label: Some("ObjectRenderer: Culling Pass"),
-                    timestamp_writes: None,
-                });
-            culling_pass.set_pipeline(&self.culling_pipeline);
-            culling_pass.set_bind_group(0, &data_bind_group, &[]);
-            culling_pass.set_immediates(0, bytemuck::bytes_of(&cull_pc));
-            culling_pass.dispatch_workgroups(
-                (instances.len() as u32).div_ceil(COMPUTE_WORKGROUP_SIZE),
-                1,
-                1,
-            );
+        // Compaction pipeline: visibility -> prefix sum -> scatter -> command.
+        // The stages together produce an order-preserving compaction of the
+        // instance indices in `visible_instances` plus the indirect draw args.
+        for stage in &self.compaction_stages {
+            stage.encode(&mut command_encoder, &data_bind_group, &stage_params);
         }
-        trace!("CoreRenderer::render: culling pass dispatched");
-
-        // command encoding pass
-        {
-            let mut command_pass =
-                command_encoder.begin_compute_pass(&wgpu::ComputePassDescriptor {
-                    label: Some("ObjectRenderer: Command Pass"),
-                    timestamp_writes: None,
-                });
-            command_pass.set_pipeline(&self.command_pipeline);
-            command_pass.set_bind_group(0, &data_bind_group, &[]);
-            command_pass.dispatch_workgroups(1, 1, 1);
-        }
-        trace!("CoreRenderer::render: command pass dispatched");
+        trace!("CoreRenderer::render: compaction stages dispatched");
 
         command_encoder.copy_buffer_to_buffer(
             &self.draw_command_storage,

--- a/renderer/src/core_renderer/renderer_cull.wgsl
+++ b/renderer/src/core_renderer/renderer_cull.wgsl
@@ -75,11 +75,12 @@ const QUAD_VERTICES = array<vec4<f32>, 4>(
     vec4<f32>(1.0, 0.0, 0.0, 1.0),
 );
 
-const CLIP_VERTICES = array<vec4<f32>, 4>(
-    vec4<f32>(-1.0,  1.0, 0.0, 1.0),
-    vec4<f32>(-1.0, -1.0, 0.0, 1.0),
-    vec4<f32>( 1.0, -1.0, 0.0, 1.0),
-    vec4<f32>( 1.0,  1.0, 0.0, 1.0),
+// Viewport corners in clip space, perimeter order.
+const CLIP_VERTICES = array<vec2<f32>, 4>(
+    vec2<f32>(-1.0,  1.0),
+    vec2<f32>(-1.0, -1.0),
+    vec2<f32>( 1.0, -1.0),
+    vec2<f32>( 1.0,  1.0),
 );
 
 @compute @workgroup_size(64)
@@ -95,27 +96,44 @@ fn culling_main(@builtin(global_invocation_id) global_id: vec3<u32>) {
     let stencil_index = max(stencil_index_add_1 - 1u, 0u);
     let stencil = all_stencils[stencil_index];
 
-    // Visible conditions:
-    // 1. instance is within the viewport
-    // 2. (no stencil) or (stencil is within the viewport)
-    // 3. instance's polygon and stencil's polygon have overlap
+    // Visible conditions (conservative: every pixel the render pass can shade
+    // lies inside texture-quad ∩ viewport, and — when a stencil masks the
+    // instance — inside texture ∩ stencil and stencil ∩ viewport as well, so
+    // the instance may be culled as soon as ANY of those pairwise
+    // intersections is provably empty):
+    // 1. instance quad overlaps the viewport
+    // 2. (no active stencil) or (stencil quad overlaps the viewport
+    //    and instance quad overlaps stencil quad)
+    //
+    // NOTE: positions are divided by w for form's sake, but the whole pipeline
+    // assumes affine transforms (w == 1); the render shader interpolates
+    // stencil UVs computed per-vertex, which would also break under a real
+    // projective transform.
 
-    var texture_position: array<vec4<f32>, 4>;
+    var texture_position: array<vec2<f32>, 4>;
     for (var i = 0u; i < 4u; i++) {
-        texture_position[i] = pc.normalize_matrix * instance.viewport_position * QUAD_VERTICES[i];
+        let p = pc.normalize_matrix * instance.viewport_position * QUAD_VERTICES[i];
+        texture_position[i] = p.xy / p.w;
     }
 
-    var stencil_position: array<vec4<f32>, 4>;
+    var stencil_position: array<vec2<f32>, 4>;
     for (var i = 0u; i < 4u; i++) {
-        stencil_position[i] = pc.normalize_matrix * stencil.viewport_position * QUAD_VERTICES[i];
+        let p = pc.normalize_matrix * stencil.viewport_position * QUAD_VERTICES[i];
+        stencil_position[i] = p.xy / p.w;
     }
+
+    // Mirror the render shader's stencil fallback: a non-invertible stencil
+    // transform draws the instance unmasked there, so it must not participate
+    // in culling here either (its degenerate quad could otherwise cull an
+    // instance the render pass would draw).
+    let stencil_active = use_stencil && (stencil.viewport_position_inverse_exists != 0u);
 
     let texture_is_in_viewport = is_overlapping(texture_position, CLIP_VERTICES);
     let stencil_is_in_viewport = is_overlapping(stencil_position, CLIP_VERTICES);
     let texture_and_stencil_overlap = is_overlapping(texture_position, stencil_position);
 
     let is_visible = texture_is_in_viewport && (
-        !use_stencil || (stencil_is_in_viewport && texture_and_stencil_overlap)
+        !stencil_active || (stencil_is_in_viewport && texture_and_stencil_overlap)
     );
 
     // IMPORTANT: compaction must preserve submission order. Instances are
@@ -128,56 +146,64 @@ fn culling_main(@builtin(global_invocation_id) global_id: vec3<u32>) {
     // flickering out). This stage therefore only emits a 0/1 visibility flag;
     // the prefix-sum + scatter stages downstream turn the flags into an
     // order-preserving compaction of `visible_instances`.
-    //
-    // TODO(follow-up): the visibility test above has a known bug, so every
-    // instance is kept for now (`is_visible` is computed but unused). Once the
-    // test is fixed, switch to: visibility_flags[instance_index] = select(0u, 1u, is_visible);
-    _ = is_visible;
-    visibility_flags[instance_index] = 1u;
+    visibility_flags[instance_index] = select(0u, 1u, is_visible);
 }
 
+//// Convex-quad overlap test via the separating axis theorem (SAT).
+////
+//// Both quads are affine images of the unit quad in perimeter order, i.e.
+//// convex (parallelograms), so SAT with the edge normals of both quads is
+//// exact. Two convex shapes are disjoint iff some edge normal is a
+//// separating axis; testing all 8 edges (with strict interval comparison
+//// inside `axis_separates`) therefore:
+////   - treats identical quads and quads sharing only a vertex/edge as
+////     overlapping (boundary-inclusive — critical because glyph instances
+////     use a stencil quad bit-identical to their texture quad; the previous
+////     vertex-containment test judged those "not overlapping" and culled
+////     every glyph),
+////   - catches cross-shaped overlaps where neither quad contains a vertex
+////     of the other (e.g. a bar wider than the viewport), which the previous
+////     test also missed.
+//// A degenerate (zero-area) quad projects to a point/segment per axis and
+//// still yields the conservative result.
 fn is_overlapping(
-    a: array<vec4<f32>, 4>,
-    b: array<vec4<f32>, 4>
+    a: array<vec2<f32>, 4>,
+    b: array<vec2<f32>, 4>
 ) -> bool {
-    var flag = false;
     for (var i = 0u; i < 4u; i++) {
-        flag = flag || point_in_polygon(a[i], b);
+        let next = (i + 1u) % 4u;
+        let edge_a = a[next] - a[i];
+        if (axis_separates(a, b, vec2<f32>(-edge_a.y, edge_a.x))) {
+            return false;
+        }
+        let edge_b = b[next] - b[i];
+        if (axis_separates(a, b, vec2<f32>(-edge_b.y, edge_b.x))) {
+            return false;
+        }
     }
-    for (var i = 0u; i < 4u; i++) {
-        flag = flag || point_in_polygon(b[i], a);
-    }
-    return flag;
+    return true;
 }
 
-fn cross_2d(a: vec2<f32>, b: vec2<f32>) -> f32 {
-    return a.x * b.y - a.y * b.x;
-}
-
-fn point_in_polygon(
-    point: vec4<f32>,
-    polygon: array<vec4<f32>, 4>
+//// True if the projections of `a` and `b` onto `axis` are strictly disjoint
+//// intervals. A zero-length edge yields a zero axis, whose projections all
+//// collapse to 0 — never reported as separating, which is the safe (keep)
+//// direction.
+fn axis_separates(
+    a: array<vec2<f32>, 4>,
+    b: array<vec2<f32>, 4>,
+    axis: vec2<f32>
 ) -> bool {
-    // use cross product to determine if the point is inside the polygon
-    let points = array<vec2<f32>, 4>(
-        polygon[0].xy - point.xy,
-        polygon[1].xy - point.xy,
-        polygon[2].xy - point.xy,
-        polygon[3].xy - point.xy,
-    );
-    let lines = array<vec2<f32>, 4>(
-        polygon[1].xy - polygon[0].xy,
-        polygon[2].xy - polygon[1].xy,
-        polygon[3].xy - polygon[2].xy,
-        polygon[0].xy - polygon[3].xy,
-    );
-
-    let signs = array<bool, 4>(
-        cross_2d(points[0], lines[0]) > 0.0,
-        cross_2d(points[1], lines[1]) > 0.0,
-        cross_2d(points[2], lines[2]) > 0.0,
-        cross_2d(points[3], lines[3]) > 0.0,
-    );
-
-    return signs[0] == signs[1] && signs[1] == signs[2] && signs[2] == signs[3];
+    var min_a = dot(a[0], axis);
+    var max_a = min_a;
+    var min_b = dot(b[0], axis);
+    var max_b = min_b;
+    for (var i = 1u; i < 4u; i++) {
+        let pa = dot(a[i], axis);
+        min_a = min(min_a, pa);
+        max_a = max(max_a, pa);
+        let pb = dot(b[i], axis);
+        min_b = min(min_b, pb);
+        max_b = max(max_b, pb);
+    }
+    return max_a < min_b || max_b < min_a;
 }

--- a/renderer/src/core_renderer/renderer_cull.wgsl
+++ b/renderer/src/core_renderer/renderer_cull.wgsl
@@ -55,8 +55,7 @@ struct StencilData {
 
 @group(0) @binding(0) var<storage, read> all_instances: array<InstanceData>;
 @group(0) @binding(1) var<storage, read> all_stencils: array<StencilData>;
-@group(0) @binding(2) var<storage, read_write> visible_instances: array<u32>;
-@group(0) @binding(3) var<storage, read_write> visible_instance_count: atomic<u32>;
+@group(0) @binding(5) var<storage, read_write> visibility_flags: array<u32>;
 
 struct Pc {
     normalize_matrix: mat4x4<f32>,
@@ -119,22 +118,22 @@ fn culling_main(@builtin(global_invocation_id) global_id: vec3<u32>) {
         !use_stencil || (stencil_is_in_viewport && texture_and_stencil_overlap)
     );
 
-    // IMPORTANT: the write below must preserve submission order. Instances are
+    // IMPORTANT: compaction must preserve submission order. Instances are
     // alpha-blended UI quads whose paint order IS their stacking order (a panel
     // background must draw before the label glyphs on top of it), and the render
     // pass draws `all_instances[visible_instances[i]]` in `i` order. An earlier
-    // version compacted with `visible_instances[atomicAdd(&count)] = index`,
+    // version compacted here with `visible_instances[atomicAdd(&count)] = index`,
     // which shuffles the array in GPU-scheduling order and intermittently drew
     // backgrounds over their own children (observed as text glyphs/images
-    // flickering out). Culling is currently disabled (every instance is kept,
-    // `is_visible` unused), so identity order is trivially correct; when real
-    // culling is implemented it must use an order-preserving compaction (e.g.
-    // prefix sum), NOT the atomicAdd pattern.
-    // todo: implement proper visibility culling (order-preserving)
-    if true {
-        atomicAdd(&visible_instance_count, 1u);
-        visible_instances[instance_index] = instance_index;
-    }
+    // flickering out). This stage therefore only emits a 0/1 visibility flag;
+    // the prefix-sum + scatter stages downstream turn the flags into an
+    // order-preserving compaction of `visible_instances`.
+    //
+    // TODO(follow-up): the visibility test above has a known bug, so every
+    // instance is kept for now (`is_visible` is computed but unused). Once the
+    // test is fixed, switch to: visibility_flags[instance_index] = select(0u, 1u, is_visible);
+    _ = is_visible;
+    visibility_flags[instance_index] = 1u;
 }
 
 fn is_overlapping(

--- a/renderer/src/core_renderer/renderer_prefix_sum_blelloch.wgsl
+++ b/renderer/src/core_renderer/renderer_prefix_sum_blelloch.wgsl
@@ -1,0 +1,161 @@
+//// Prefix-sum stage of the order-preserving stream compaction, default
+//// implementation: two-level Blelloch (work-efficient) scan.
+////
+//// Stage contract (identical to renderer_prefix_sum_single_thread.wgsl — the
+//// two implementations are interchangeable behind the Rust `ComputeStage`
+//// trait):
+////   input : visibility_flags[0 .. instance_count]   (each element 0 or 1)
+////   output: scan_offsets[i] = exclusive prefix sum of visibility_flags,
+////           i.e. the compacted slot that instance i scatters into when its
+////           flag is set. Monotonically non-decreasing in i, which is what
+////           guarantees that compaction preserves submission (paint) order.
+////           visible_instance_count = total number of set flags.
+////
+//// Structure (three dispatches, in order, recorded by BlellochPrefixSumStage):
+////   1. scan_blocks       — each workgroup Blelloch-scans one block of
+////                          BLOCK_ELEMENTS flags in workgroup memory, writes
+////                          the per-element exclusive results to scan_offsets
+////                          and the block total to block_sums[block].
+////   2. scan_block_sums   — a single workgroup Blelloch-scans block_sums in
+////                          place (exclusive) and stores the grand total to
+////                          visible_instance_count.
+////   3. add_block_offsets — each element adds its block's scanned base offset.
+////
+//// Capacity: MAX_BLOCKS * BLOCK_ELEMENTS = 262,144 elements. The Rust stage
+//// falls back to the single-thread implementation above this limit.
+
+@group(0) @binding(3) var<storage, read_write> visible_instance_count: atomic<u32>;
+@group(0) @binding(5) var<storage, read_write> visibility_flags: array<u32>;
+@group(0) @binding(6) var<storage, read_write> scan_offsets: array<u32>;
+// Stage-internal scratch buffer, owned by BlellochPrefixSumStage (not part of
+// the shared data bind group). One u32 per block, MAX_BLOCKS entries.
+@group(1) @binding(0) var<storage, read_write> block_sums: array<u32>;
+
+struct Pc {
+    instance_count: u32,
+};
+var<immediate> pc: Pc;
+
+const WORKGROUP_SIZE: u32 = 256u;
+// Each thread owns two elements of the shared scratch array.
+const BLOCK_ELEMENTS: u32 = 512u;
+const MAX_BLOCKS: u32 = 512u;
+
+var<workgroup> scratch: array<u32, BLOCK_ELEMENTS>;
+
+//// Exclusive Blelloch scan over the whole `scratch` array (classic GPU Gems 3
+//// formulation: up-sweep to a reduction tree, clear the root, down-sweep).
+//// Thread `t` owns elements 2t and 2t+1. Returns the total of all inputs
+//// (valid in every thread). Must be called from uniform control flow.
+fn scan_scratch_exclusive(t: u32) -> u32 {
+    // Up-sweep (reduce).
+    var offset = 1u;
+    for (var d = BLOCK_ELEMENTS / 2u; d > 0u; d = d >> 1u) {
+        workgroupBarrier();
+        if (t < d) {
+            let ai = offset * (2u * t + 1u) - 1u;
+            let bi = offset * (2u * t + 2u) - 1u;
+            scratch[bi] += scratch[ai];
+        }
+        offset = offset << 1u;
+    }
+
+    // The root now holds the total; broadcast it before clearing.
+    workgroupBarrier();
+    let total = scratch[BLOCK_ELEMENTS - 1u];
+    workgroupBarrier();
+    if (t == 0u) {
+        scratch[BLOCK_ELEMENTS - 1u] = 0u;
+    }
+
+    // Down-sweep.
+    for (var d = 1u; d < BLOCK_ELEMENTS; d = d << 1u) {
+        offset = offset >> 1u;
+        workgroupBarrier();
+        if (t < d) {
+            let ai = offset * (2u * t + 1u) - 1u;
+            let bi = offset * (2u * t + 2u) - 1u;
+            let tmp = scratch[ai];
+            scratch[ai] = scratch[bi];
+            scratch[bi] += tmp;
+        }
+    }
+    workgroupBarrier();
+
+    return total;
+}
+
+@compute @workgroup_size(256)
+fn scan_blocks(
+    @builtin(local_invocation_id) local_id: vec3<u32>,
+    @builtin(workgroup_id) workgroup_id: vec3<u32>,
+) {
+    let t = local_id.x;
+    let base = workgroup_id.x * BLOCK_ELEMENTS;
+
+    // Load two elements per thread, zero-padding past instance_count so the
+    // scan of a partial tail block stays correct.
+    for (var k = 0u; k < 2u; k++) {
+        let i = 2u * t + k;
+        let g = base + i;
+        if (g < pc.instance_count) {
+            scratch[i] = visibility_flags[g];
+        } else {
+            scratch[i] = 0u;
+        }
+    }
+
+    let block_total = scan_scratch_exclusive(t);
+
+    if (t == 0u) {
+        block_sums[workgroup_id.x] = block_total;
+    }
+
+    for (var k = 0u; k < 2u; k++) {
+        let i = 2u * t + k;
+        let g = base + i;
+        if (g < pc.instance_count) {
+            scan_offsets[g] = scratch[i];
+        }
+    }
+}
+
+@compute @workgroup_size(256)
+fn scan_block_sums(@builtin(local_invocation_id) local_id: vec3<u32>) {
+    let t = local_id.x;
+    let num_blocks = (pc.instance_count + BLOCK_ELEMENTS - 1u) / BLOCK_ELEMENTS;
+
+    // Zero-pad: block_sums entries beyond num_blocks are stale scratch from
+    // previous frames and must not contribute.
+    for (var k = 0u; k < 2u; k++) {
+        let i = 2u * t + k;
+        if (i < num_blocks) {
+            scratch[i] = block_sums[i];
+        } else {
+            scratch[i] = 0u;
+        }
+    }
+
+    let total = scan_scratch_exclusive(t);
+
+    if (t == 0u) {
+        atomicStore(&visible_instance_count, total);
+    }
+
+    for (var k = 0u; k < 2u; k++) {
+        let i = 2u * t + k;
+        if (i < num_blocks) {
+            block_sums[i] = scratch[i];
+        }
+    }
+}
+
+@compute @workgroup_size(256)
+fn add_block_offsets(@builtin(global_invocation_id) global_id: vec3<u32>) {
+    let i = global_id.x;
+    if (i >= pc.instance_count) {
+        return;
+    }
+    // block_sums[0] is 0 after the exclusive scan, so block 0 is a no-op add.
+    scan_offsets[i] += block_sums[i / BLOCK_ELEMENTS];
+}

--- a/renderer/src/core_renderer/renderer_prefix_sum_single_thread.wgsl
+++ b/renderer/src/core_renderer/renderer_prefix_sum_single_thread.wgsl
@@ -1,0 +1,30 @@
+//// Prefix-sum stage of the order-preserving stream compaction, reference
+//// implementation: a single GPU thread performs a naive sequential scan.
+////
+//// Stage contract (identical to renderer_prefix_sum_blelloch.wgsl — the two
+//// implementations are interchangeable behind the Rust `ComputeStage` trait):
+////   input : visibility_flags[0 .. instance_count]   (each element 0 or 1)
+////   output: scan_offsets[i] = exclusive prefix sum of visibility_flags,
+////           i.e. the compacted slot that instance i scatters into when its
+////           flag is set. Monotonically non-decreasing in i, which is what
+////           guarantees that compaction preserves submission (paint) order.
+////           visible_instance_count = total number of set flags.
+
+@group(0) @binding(3) var<storage, read_write> visible_instance_count: atomic<u32>;
+@group(0) @binding(5) var<storage, read_write> visibility_flags: array<u32>;
+@group(0) @binding(6) var<storage, read_write> scan_offsets: array<u32>;
+
+struct Pc {
+    instance_count: u32,
+};
+var<immediate> pc: Pc;
+
+@compute @workgroup_size(1)
+fn prefix_sum_main() {
+    var sum = 0u;
+    for (var i = 0u; i < pc.instance_count; i++) {
+        scan_offsets[i] = sum;
+        sum += visibility_flags[i];
+    }
+    atomicStore(&visible_instance_count, sum);
+}

--- a/renderer/src/core_renderer/renderer_scatter.wgsl
+++ b/renderer/src/core_renderer/renderer_scatter.wgsl
@@ -1,0 +1,29 @@
+//// Scatter stage of the order-preserving stream compaction.
+////
+//// Consumes the visibility flags and their exclusive prefix sums and writes
+//// the compacted index list: every visible instance i lands in
+//// visible_instances[scan_offsets[i]]. Because scan_offsets is an exclusive
+//// prefix sum computed from the flags, the destination slots are unique and
+//// strictly increasing in i, so the compacted array keeps submission (paint)
+//// order regardless of GPU thread scheduling — unlike the old
+//// `visible_instances[atomicAdd(&count)] = i` pattern.
+
+@group(0) @binding(2) var<storage, read_write> visible_instances: array<u32>;
+@group(0) @binding(5) var<storage, read_write> visibility_flags: array<u32>;
+@group(0) @binding(6) var<storage, read_write> scan_offsets: array<u32>;
+
+struct Pc {
+    instance_count: u32,
+};
+var<immediate> pc: Pc;
+
+@compute @workgroup_size(64)
+fn scatter_main(@builtin(global_invocation_id) global_id: vec3<u32>) {
+    let instance_index = global_id.x;
+    if (instance_index >= pc.instance_count) {
+        return;
+    }
+    if (visibility_flags[instance_index] != 0u) {
+        visible_instances[scan_offsets[instance_index]] = instance_index;
+    }
+}

--- a/renderer/src/core_renderer/stages.rs
+++ b/renderer/src/core_renderer/stages.rs
@@ -1,0 +1,711 @@
+//! Swappable compute stages of the culling / stream-compaction pipeline.
+//!
+//! `CoreRenderer` turns the ordered `all_instances` array into the compacted
+//! `visible_instances` index list with a sequence of compute stages:
+//!
+//! 1. [`VisibilityStage`] — per-instance visibility test, emits 0/1 flags.
+//! 2. a prefix-sum stage — exclusive scan of the flags into per-instance
+//!    compaction offsets + the visible total ([`BlellochPrefixSumStage`] by
+//!    default, [`SingleThreadPrefixSumStage`] as the naive reference).
+//! 3. [`ScatterStage`] — writes each visible instance index to its scanned
+//!    offset, preserving submission (paint) order by construction.
+//! 4. [`CommandStage`] — converts the visible count into indirect draw args.
+//!
+//! Every stage implements [`ComputeStage`] and only communicates with its
+//! neighbours through the shared data bind group (see the bind group layout in
+//! `core_renderer.rs`), so swapping an algorithm — e.g. replacing the scan
+//! implementation — only means constructing a different stage in
+//! `CoreRendererInner::new`. A stage may record any number of dispatches (the
+//! Blelloch scan records three).
+
+use log::warn;
+
+/// Threads per workgroup for the simple one-thread-per-instance stages
+/// (visibility test, scatter). Must match `@workgroup_size` in
+/// `renderer_cull.wgsl` and `renderer_scatter.wgsl`.
+pub(crate) const COMPUTE_WORKGROUP_SIZE: u32 = 64;
+
+const WGSL_CULL: &str = include_str!("renderer_cull.wgsl");
+const WGSL_PREFIX_SUM_BLELLOCH: &str = include_str!("renderer_prefix_sum_blelloch.wgsl");
+const WGSL_PREFIX_SUM_SINGLE_THREAD: &str =
+    include_str!("renderer_prefix_sum_single_thread.wgsl");
+const WGSL_SCATTER: &str = include_str!("renderer_scatter.wgsl");
+const WGSL_COMMAND: &str = include_str!("renderer_command.wgsl");
+
+/// Per-frame parameters shared by all compute stages. Each stage picks what it
+/// needs and packs its own immediates from these.
+pub(crate) struct StageParams {
+    pub normalize_matrix: nalgebra::Matrix4<f32>,
+    pub instance_count: u32,
+}
+
+/// One compute stage of the compaction pipeline. Implementations own their
+/// pipeline(s) and any internal resources, and record their dispatches into
+/// the frame's command encoder. Stages run in the order they are stored in
+/// `CoreRendererInner::compaction_stages`; wgpu inserts the storage-buffer
+/// barriers between dispatches.
+pub(crate) trait ComputeStage: Send + Sync {
+    fn encode(
+        &self,
+        encoder: &mut wgpu::CommandEncoder,
+        data_bind_group: &wgpu::BindGroup,
+        params: &StageParams,
+    );
+}
+
+/// Immediates for [`VisibilityStage`]. Layout must match `Pc` in
+/// `renderer_cull.wgsl`.
+#[repr(C)]
+#[derive(Copy, Clone, Debug, bytemuck::Pod, bytemuck::Zeroable)]
+struct VisibilityPushConstants {
+    normalize_matrix: nalgebra::Matrix4<f32>,
+    instance_count: u32,
+    _pad: [u32; 3],
+}
+
+/// Immediates for the prefix-sum and scatter stages. Layout must match `Pc`
+/// in the corresponding WGSL files.
+#[repr(C)]
+#[derive(Copy, Clone, Debug, bytemuck::Pod, bytemuck::Zeroable)]
+struct InstanceCountPushConstants {
+    instance_count: u32,
+}
+
+fn create_compute_pipeline(
+    device: &wgpu::Device,
+    label: &str,
+    module: &wgpu::ShaderModule,
+    entry_point: &str,
+    bind_group_layouts: &[Option<&wgpu::BindGroupLayout>],
+    immediate_size: u32,
+) -> wgpu::ComputePipeline {
+    let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+        label: Some(&format!("{label} Layout")),
+        bind_group_layouts,
+        immediate_size,
+    });
+    device.create_compute_pipeline(&wgpu::ComputePipelineDescriptor {
+        label: Some(label),
+        layout: Some(&pipeline_layout),
+        module,
+        entry_point: Some(entry_point),
+        compilation_options: Default::default(),
+        cache: None,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Visibility stage
+// ---------------------------------------------------------------------------
+
+/// Per-instance visibility test (`renderer_cull.wgsl`): writes a 0/1 flag per
+/// instance into `visibility_flags`. Currently every instance is flagged
+/// visible (the geometric test has a known bug and is bypassed in the shader;
+/// see the TODO there).
+pub(crate) struct VisibilityStage {
+    pipeline: wgpu::ComputePipeline,
+}
+
+impl VisibilityStage {
+    pub fn new(device: &wgpu::Device, data_bind_group_layout: &wgpu::BindGroupLayout) -> Self {
+        let module = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+            label: Some("Visibility Shader"),
+            source: wgpu::ShaderSource::Wgsl(WGSL_CULL.into()),
+        });
+        let pipeline = create_compute_pipeline(
+            device,
+            "Visibility Pipeline",
+            &module,
+            "culling_main",
+            &[Some(data_bind_group_layout)],
+            std::mem::size_of::<VisibilityPushConstants>() as u32,
+        );
+        Self { pipeline }
+    }
+}
+
+impl ComputeStage for VisibilityStage {
+    fn encode(
+        &self,
+        encoder: &mut wgpu::CommandEncoder,
+        data_bind_group: &wgpu::BindGroup,
+        params: &StageParams,
+    ) {
+        let pc = VisibilityPushConstants {
+            normalize_matrix: params.normalize_matrix,
+            instance_count: params.instance_count,
+            _pad: [0; 3],
+        };
+        let mut pass = encoder.begin_compute_pass(&wgpu::ComputePassDescriptor {
+            label: Some("ObjectRenderer: Visibility Pass"),
+            timestamp_writes: None,
+        });
+        pass.set_pipeline(&self.pipeline);
+        pass.set_bind_group(0, data_bind_group, &[]);
+        pass.set_immediates(0, bytemuck::bytes_of(&pc));
+        pass.dispatch_workgroups(
+            params.instance_count.div_ceil(COMPUTE_WORKGROUP_SIZE),
+            1,
+            1,
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Prefix-sum stages
+// ---------------------------------------------------------------------------
+
+/// Naive reference prefix-sum stage: one GPU thread scans the whole flag array
+/// sequentially (`renderer_prefix_sum_single_thread.wgsl`). Trivially correct
+/// and unbounded, but serial; kept as the drop-in fallback / bisection tool
+/// for [`BlellochPrefixSumStage`].
+pub(crate) struct SingleThreadPrefixSumStage {
+    pipeline: wgpu::ComputePipeline,
+}
+
+impl SingleThreadPrefixSumStage {
+    pub fn new(device: &wgpu::Device, data_bind_group_layout: &wgpu::BindGroupLayout) -> Self {
+        let module = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+            label: Some("Prefix Sum Shader (single thread)"),
+            source: wgpu::ShaderSource::Wgsl(WGSL_PREFIX_SUM_SINGLE_THREAD.into()),
+        });
+        let pipeline = create_compute_pipeline(
+            device,
+            "Prefix Sum Pipeline (single thread)",
+            &module,
+            "prefix_sum_main",
+            &[Some(data_bind_group_layout)],
+            std::mem::size_of::<InstanceCountPushConstants>() as u32,
+        );
+        Self { pipeline }
+    }
+}
+
+impl ComputeStage for SingleThreadPrefixSumStage {
+    fn encode(
+        &self,
+        encoder: &mut wgpu::CommandEncoder,
+        data_bind_group: &wgpu::BindGroup,
+        params: &StageParams,
+    ) {
+        let pc = InstanceCountPushConstants {
+            instance_count: params.instance_count,
+        };
+        let mut pass = encoder.begin_compute_pass(&wgpu::ComputePassDescriptor {
+            label: Some("ObjectRenderer: Prefix Sum Pass (single thread)"),
+            timestamp_writes: None,
+        });
+        pass.set_pipeline(&self.pipeline);
+        pass.set_bind_group(0, data_bind_group, &[]);
+        pass.set_immediates(0, bytemuck::bytes_of(&pc));
+        pass.dispatch_workgroups(1, 1, 1);
+    }
+}
+
+/// Elements scanned per workgroup by the Blelloch scan (2 per thread). Must
+/// match `BLOCK_ELEMENTS` in `renderer_prefix_sum_blelloch.wgsl`.
+const BLELLOCH_BLOCK_ELEMENTS: u32 = 512;
+/// Capacity of the block-sums pass (one workgroup scans all block sums). Must
+/// match `MAX_BLOCKS` in `renderer_prefix_sum_blelloch.wgsl`.
+const BLELLOCH_MAX_BLOCKS: u32 = 512;
+/// Maximum instance count the two-level scan supports.
+const BLELLOCH_MAX_ELEMENTS: u32 = BLELLOCH_BLOCK_ELEMENTS * BLELLOCH_MAX_BLOCKS;
+
+/// Default prefix-sum stage: two-level work-efficient Blelloch scan
+/// (`renderer_prefix_sum_blelloch.wgsl`, three dispatches). Owns its
+/// `block_sums` scratch buffer as a private second bind group so the shared
+/// data bind group layout stays algorithm-agnostic. Falls back to the
+/// single-thread scan beyond [`BLELLOCH_MAX_ELEMENTS`] instances.
+pub(crate) struct BlellochPrefixSumStage {
+    scan_blocks_pipeline: wgpu::ComputePipeline,
+    scan_block_sums_pipeline: wgpu::ComputePipeline,
+    add_block_offsets_pipeline: wgpu::ComputePipeline,
+    block_sums_bind_group: wgpu::BindGroup,
+    fallback: SingleThreadPrefixSumStage,
+}
+
+impl BlellochPrefixSumStage {
+    pub fn new(device: &wgpu::Device, data_bind_group_layout: &wgpu::BindGroupLayout) -> Self {
+        let block_sums_bind_group_layout =
+            device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+                label: Some("Blelloch Block Sums Bind Group Layout"),
+                entries: &[wgpu::BindGroupLayoutEntry {
+                    binding: 0,
+                    visibility: wgpu::ShaderStages::COMPUTE,
+                    ty: wgpu::BindingType::Buffer {
+                        ty: wgpu::BufferBindingType::Storage { read_only: false },
+                        has_dynamic_offset: false,
+                        min_binding_size: None,
+                    },
+                    count: None,
+                }],
+            });
+
+        let block_sums_buffer = device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("Blelloch Block Sums Buffer"),
+            size: (std::mem::size_of::<u32>() as u64) * BLELLOCH_MAX_BLOCKS as u64,
+            usage: wgpu::BufferUsages::STORAGE,
+            mapped_at_creation: false,
+        });
+
+        let block_sums_bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("Blelloch Block Sums Bind Group"),
+            layout: &block_sums_bind_group_layout,
+            entries: &[wgpu::BindGroupEntry {
+                binding: 0,
+                resource: block_sums_buffer.as_entire_binding(),
+            }],
+        });
+
+        let module = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+            label: Some("Prefix Sum Shader (Blelloch)"),
+            source: wgpu::ShaderSource::Wgsl(WGSL_PREFIX_SUM_BLELLOCH.into()),
+        });
+        let layouts = [
+            Some(data_bind_group_layout),
+            Some(&block_sums_bind_group_layout),
+        ];
+        let immediate_size = std::mem::size_of::<InstanceCountPushConstants>() as u32;
+        let scan_blocks_pipeline = create_compute_pipeline(
+            device,
+            "Blelloch Scan Blocks Pipeline",
+            &module,
+            "scan_blocks",
+            &layouts,
+            immediate_size,
+        );
+        let scan_block_sums_pipeline = create_compute_pipeline(
+            device,
+            "Blelloch Scan Block Sums Pipeline",
+            &module,
+            "scan_block_sums",
+            &layouts,
+            immediate_size,
+        );
+        let add_block_offsets_pipeline = create_compute_pipeline(
+            device,
+            "Blelloch Add Block Offsets Pipeline",
+            &module,
+            "add_block_offsets",
+            &layouts,
+            immediate_size,
+        );
+
+        Self {
+            scan_blocks_pipeline,
+            scan_block_sums_pipeline,
+            add_block_offsets_pipeline,
+            block_sums_bind_group,
+            fallback: SingleThreadPrefixSumStage::new(device, data_bind_group_layout),
+        }
+    }
+}
+
+impl ComputeStage for BlellochPrefixSumStage {
+    fn encode(
+        &self,
+        encoder: &mut wgpu::CommandEncoder,
+        data_bind_group: &wgpu::BindGroup,
+        params: &StageParams,
+    ) {
+        if params.instance_count > BLELLOCH_MAX_ELEMENTS {
+            warn!(
+                "BlellochPrefixSumStage: {} instances exceed the two-level scan capacity ({}); \
+                 falling back to the single-thread scan",
+                params.instance_count, BLELLOCH_MAX_ELEMENTS
+            );
+            self.fallback.encode(encoder, data_bind_group, params);
+            return;
+        }
+
+        let pc = InstanceCountPushConstants {
+            instance_count: params.instance_count,
+        };
+        let num_blocks = params.instance_count.div_ceil(BLELLOCH_BLOCK_ELEMENTS);
+
+        let mut pass = encoder.begin_compute_pass(&wgpu::ComputePassDescriptor {
+            label: Some("ObjectRenderer: Prefix Sum Pass (Blelloch)"),
+            timestamp_writes: None,
+        });
+        pass.set_bind_group(0, data_bind_group, &[]);
+        pass.set_bind_group(1, &self.block_sums_bind_group, &[]);
+
+        pass.set_pipeline(&self.scan_blocks_pipeline);
+        pass.set_immediates(0, bytemuck::bytes_of(&pc));
+        pass.dispatch_workgroups(num_blocks, 1, 1);
+
+        pass.set_pipeline(&self.scan_block_sums_pipeline);
+        pass.set_immediates(0, bytemuck::bytes_of(&pc));
+        pass.dispatch_workgroups(1, 1, 1);
+
+        pass.set_pipeline(&self.add_block_offsets_pipeline);
+        pass.set_immediates(0, bytemuck::bytes_of(&pc));
+        // One thread per element here (unlike scan_blocks' two per thread).
+        pass.dispatch_workgroups(params.instance_count.div_ceil(256), 1, 1);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Scatter stage
+// ---------------------------------------------------------------------------
+
+/// Writes each visible instance index to its scanned offset in
+/// `visible_instances` (`renderer_scatter.wgsl`), completing the
+/// order-preserving compaction.
+pub(crate) struct ScatterStage {
+    pipeline: wgpu::ComputePipeline,
+}
+
+impl ScatterStage {
+    pub fn new(device: &wgpu::Device, data_bind_group_layout: &wgpu::BindGroupLayout) -> Self {
+        let module = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+            label: Some("Scatter Shader"),
+            source: wgpu::ShaderSource::Wgsl(WGSL_SCATTER.into()),
+        });
+        let pipeline = create_compute_pipeline(
+            device,
+            "Scatter Pipeline",
+            &module,
+            "scatter_main",
+            &[Some(data_bind_group_layout)],
+            std::mem::size_of::<InstanceCountPushConstants>() as u32,
+        );
+        Self { pipeline }
+    }
+}
+
+impl ComputeStage for ScatterStage {
+    fn encode(
+        &self,
+        encoder: &mut wgpu::CommandEncoder,
+        data_bind_group: &wgpu::BindGroup,
+        params: &StageParams,
+    ) {
+        let pc = InstanceCountPushConstants {
+            instance_count: params.instance_count,
+        };
+        let mut pass = encoder.begin_compute_pass(&wgpu::ComputePassDescriptor {
+            label: Some("ObjectRenderer: Scatter Pass"),
+            timestamp_writes: None,
+        });
+        pass.set_pipeline(&self.pipeline);
+        pass.set_bind_group(0, data_bind_group, &[]);
+        pass.set_immediates(0, bytemuck::bytes_of(&pc));
+        pass.dispatch_workgroups(
+            params.instance_count.div_ceil(COMPUTE_WORKGROUP_SIZE),
+            1,
+            1,
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Command stage
+// ---------------------------------------------------------------------------
+
+/// Converts `visible_instance_count` into the indirect draw arguments
+/// (`renderer_command.wgsl`).
+pub(crate) struct CommandStage {
+    pipeline: wgpu::ComputePipeline,
+}
+
+impl CommandStage {
+    pub fn new(device: &wgpu::Device, data_bind_group_layout: &wgpu::BindGroupLayout) -> Self {
+        let module = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+            label: Some("Command Shader"),
+            source: wgpu::ShaderSource::Wgsl(WGSL_COMMAND.into()),
+        });
+        let pipeline = create_compute_pipeline(
+            device,
+            "Command Pipeline",
+            &module,
+            "command_main",
+            &[Some(data_bind_group_layout)],
+            0,
+        );
+        Self { pipeline }
+    }
+}
+
+impl ComputeStage for CommandStage {
+    fn encode(
+        &self,
+        encoder: &mut wgpu::CommandEncoder,
+        data_bind_group: &wgpu::BindGroup,
+        _params: &StageParams,
+    ) {
+        let mut pass = encoder.begin_compute_pass(&wgpu::ComputePassDescriptor {
+            label: Some("ObjectRenderer: Command Pass"),
+            timestamp_writes: None,
+        });
+        pass.set_pipeline(&self.pipeline);
+        pass.set_bind_group(0, data_bind_group, &[]);
+        pass.dispatch_workgroups(1, 1, 1);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    //! Correctness tests for the prefix-sum stage contract, checked against a
+    //! CPU exclusive scan. These need a real GPU adapter (the noop backend
+    //! does not execute shaders) and skip themselves when none is available —
+    //! run `cargo test -p renderer` on a machine with a GPU to exercise them.
+
+    use super::*;
+
+    struct TestGpu {
+        device: wgpu::Device,
+        queue: wgpu::Queue,
+        data_bind_group_layout: wgpu::BindGroupLayout,
+    }
+
+    fn test_gpu() -> Option<TestGpu> {
+        let gpu = futures::executor::block_on(gpu_utils::gpu::Gpu::new(
+            gpu_utils::gpu::GpuDescriptor::default(),
+        ))
+        .ok()?;
+        let (device, queue) = gpu.context()?;
+        let data_bind_group_layout = crate::core_renderer::create_data_bind_group_layout(&device);
+        Some(TestGpu {
+            device,
+            queue,
+            data_bind_group_layout,
+        })
+    }
+
+    fn cpu_exclusive_scan(flags: &[u32]) -> (Vec<u32>, u32) {
+        let mut offsets = Vec::with_capacity(flags.len());
+        let mut sum = 0u32;
+        for &f in flags {
+            offsets.push(sum);
+            sum += f;
+        }
+        (offsets, sum)
+    }
+
+    /// Run a chain of stages over `flags` and read back
+    /// (scan_offsets, count, visible_instances[..count]).
+    fn run_stages(
+        gpu: &TestGpu,
+        stages: &[&dyn ComputeStage],
+        flags: &[u32],
+    ) -> (Vec<u32>, u32, Vec<u32>) {
+        let device = &gpu.device;
+        let n = flags.len();
+        let u32_size = std::mem::size_of::<u32>() as u64;
+        let flags_bytes = u32_size * n as u64;
+
+        let make_storage = |label: &str, size: u64, extra: wgpu::BufferUsages| {
+            device.create_buffer(&wgpu::BufferDescriptor {
+                label: Some(label),
+                size,
+                usage: wgpu::BufferUsages::STORAGE | extra,
+                mapped_at_creation: false,
+            })
+        };
+
+        // Bindings the scan stages don't touch still need buffers to build the
+        // shared bind group; small dummies suffice (dispatch-time validation
+        // only covers bindings the pipeline actually uses).
+        let dummy_instances = make_storage("test instances", 96, wgpu::BufferUsages::empty());
+        let dummy_stencils = make_storage("test stencils", 176, wgpu::BufferUsages::empty());
+        let visible_instances = make_storage(
+            "test visible_instances",
+            flags_bytes,
+            wgpu::BufferUsages::COPY_SRC | wgpu::BufferUsages::COPY_DST,
+        );
+        let counter = make_storage(
+            "test counter",
+            u32_size,
+            wgpu::BufferUsages::COPY_SRC | wgpu::BufferUsages::COPY_DST,
+        );
+        let draw_command = make_storage("test draw_command", 16, wgpu::BufferUsages::empty());
+        let flags_buffer = make_storage(
+            "test visibility_flags",
+            flags_bytes,
+            wgpu::BufferUsages::COPY_DST,
+        );
+        let offsets_buffer = make_storage(
+            "test scan_offsets",
+            flags_bytes,
+            wgpu::BufferUsages::COPY_SRC | wgpu::BufferUsages::COPY_DST,
+        );
+
+        let data_bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("test data bind group"),
+            layout: &gpu.data_bind_group_layout,
+            entries: &[
+                wgpu::BindGroupEntry {
+                    binding: 0,
+                    resource: dummy_instances.as_entire_binding(),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 1,
+                    resource: dummy_stencils.as_entire_binding(),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 2,
+                    resource: visible_instances.as_entire_binding(),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 3,
+                    resource: counter.as_entire_binding(),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 4,
+                    resource: draw_command.as_entire_binding(),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 5,
+                    resource: flags_buffer.as_entire_binding(),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 6,
+                    resource: offsets_buffer.as_entire_binding(),
+                },
+            ],
+        });
+
+        gpu.queue
+            .write_buffer(&flags_buffer, 0, bytemuck::cast_slice(flags));
+        // Poison the outputs so stale zeroes can't fake a pass.
+        gpu.queue
+            .write_buffer(&offsets_buffer, 0, &vec![0xffu8; flags_bytes as usize]);
+        gpu.queue
+            .write_buffer(&counter, 0, bytemuck::bytes_of(&0xdead_beefu32));
+        gpu.queue
+            .write_buffer(&visible_instances, 0, &vec![0xffu8; flags_bytes as usize]);
+
+        let make_readback = |label: &str, size: u64| {
+            device.create_buffer(&wgpu::BufferDescriptor {
+                label: Some(label),
+                size,
+                usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::MAP_READ,
+                mapped_at_creation: false,
+            })
+        };
+        let readback_offsets = make_readback("test readback offsets", flags_bytes);
+        let readback_count = make_readback("test readback count", u32_size);
+        let readback_visible = make_readback("test readback visible", flags_bytes);
+
+        let mut encoder =
+            device.create_command_encoder(&wgpu::CommandEncoderDescriptor { label: None });
+        let params = StageParams {
+            normalize_matrix: nalgebra::Matrix4::identity(),
+            instance_count: n as u32,
+        };
+        for stage in stages {
+            stage.encode(&mut encoder, &data_bind_group, &params);
+        }
+        encoder.copy_buffer_to_buffer(&offsets_buffer, 0, &readback_offsets, 0, flags_bytes);
+        encoder.copy_buffer_to_buffer(&counter, 0, &readback_count, 0, u32_size);
+        encoder.copy_buffer_to_buffer(&visible_instances, 0, &readback_visible, 0, flags_bytes);
+        gpu.queue.submit(std::iter::once(encoder.finish()));
+
+        for buffer in [&readback_offsets, &readback_count, &readback_visible] {
+            buffer
+                .slice(..)
+                .map_async(wgpu::MapMode::Read, |r| r.expect("buffer map"));
+        }
+        device
+            .poll(wgpu::PollType::wait_indefinitely())
+            .expect("device poll");
+
+        let offsets: Vec<u32> =
+            bytemuck::cast_slice(&readback_offsets.slice(..).get_mapped_range()).to_vec();
+        let count: u32 =
+            bytemuck::cast_slice::<u8, u32>(&readback_count.slice(..).get_mapped_range())[0];
+        let visible: Vec<u32> = bytemuck::cast_slice::<u8, u32>(
+            &readback_visible.slice(..).get_mapped_range(),
+        )[..count as usize]
+            .to_vec();
+        (offsets, count, visible)
+    }
+
+    /// Deterministic pseudo-random 0/1 flags (xorshift).
+    fn random_flags(n: usize, mut seed: u32) -> Vec<u32> {
+        (0..n)
+            .map(|_| {
+                seed ^= seed << 13;
+                seed ^= seed >> 17;
+                seed ^= seed << 5;
+                seed & 1
+            })
+            .collect()
+    }
+
+    fn check_stage_against_cpu(gpu: &TestGpu, stage: &dyn ComputeStage, label: &str) {
+        // Lengths chosen around the Blelloch block boundaries (512 elements
+        // per block) plus small and large irregular sizes.
+        let lengths = [1usize, 3, 64, 511, 512, 513, 1000, 1024, 4096, 70_000];
+        for &n in &lengths {
+            let patterns: [(&str, Vec<u32>); 3] = [
+                ("all-ones", vec![1u32; n]),
+                ("all-zeros", vec![0u32; n]),
+                ("random", random_flags(n, 0x9e37_79b9 ^ n as u32)),
+            ];
+            for (pattern, flags) in &patterns {
+                let (gpu_offsets, gpu_count, _) = run_stages(gpu, &[stage], flags);
+                let (cpu_offsets, cpu_count) = cpu_exclusive_scan(flags);
+                assert_eq!(
+                    gpu_count, cpu_count,
+                    "{label}: total mismatch (n={n}, pattern={pattern})"
+                );
+                assert_eq!(
+                    gpu_offsets, cpu_offsets,
+                    "{label}: offsets mismatch (n={n}, pattern={pattern})"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn single_thread_prefix_sum_matches_cpu_scan() {
+        let Some(gpu) = test_gpu() else {
+            eprintln!("skipping: no real GPU adapter available");
+            return;
+        };
+        let stage = SingleThreadPrefixSumStage::new(&gpu.device, &gpu.data_bind_group_layout);
+        check_stage_against_cpu(&gpu, &stage, "single-thread scan");
+    }
+
+    #[test]
+    fn blelloch_prefix_sum_matches_cpu_scan() {
+        let Some(gpu) = test_gpu() else {
+            eprintln!("skipping: no real GPU adapter available");
+            return;
+        };
+        let stage = BlellochPrefixSumStage::new(&gpu.device, &gpu.data_bind_group_layout);
+        check_stage_against_cpu(&gpu, &stage, "Blelloch scan");
+    }
+
+    /// End-to-end property of the compaction (scan + scatter): the compacted
+    /// `visible_instances` array is exactly the flagged indices in ascending
+    /// (submission/paint) order — the invariant whose violation caused the
+    /// original intermittent draw-order bug.
+    #[test]
+    fn scan_plus_scatter_compacts_in_submission_order() {
+        let Some(gpu) = test_gpu() else {
+            eprintln!("skipping: no real GPU adapter available");
+            return;
+        };
+        let scan = BlellochPrefixSumStage::new(&gpu.device, &gpu.data_bind_group_layout);
+        let scatter = ScatterStage::new(&gpu.device, &gpu.data_bind_group_layout);
+        for n in [1usize, 64, 511, 513, 1000, 70_000] {
+            let flags = random_flags(n, n as u32 | 1);
+            let (_, count, visible) = run_stages(&gpu, &[&scan, &scatter], &flags);
+            let expected: Vec<u32> = flags
+                .iter()
+                .enumerate()
+                .filter(|&(_, &f)| f != 0)
+                .map(|(i, _)| i as u32)
+                .collect();
+            assert_eq!(count as usize, expected.len(), "count mismatch (n={n})");
+            assert_eq!(visible, expected, "compaction order mismatch (n={n})");
+        }
+    }
+}

--- a/renderer/src/core_renderer/stages.rs
+++ b/renderer/src/core_renderer/stages.rs
@@ -450,12 +450,15 @@ impl ComputeStage for CommandStage {
 
 #[cfg(test)]
 mod tests {
-    //! Correctness tests for the prefix-sum stage contract, checked against a
-    //! CPU exclusive scan. These need a real GPU adapter (the noop backend
-    //! does not execute shaders) and skip themselves when none is available —
-    //! run `cargo test -p renderer` on a machine with a GPU to exercise them.
+    //! Correctness tests for the compute stages: the prefix-sum contract is
+    //! checked against a CPU exclusive scan, and the visibility stage against
+    //! hand-computed cull expectations. These need a real GPU adapter (the
+    //! noop backend does not execute shaders) and skip themselves when none
+    //! is available — run `cargo test -p renderer` on a machine with a GPU
+    //! to exercise them.
 
     use super::*;
+    use crate::core_renderer::{InstanceData, StencilData, make_normalize_matrix};
 
     struct TestGpu {
         device: wgpu::Device,
@@ -706,6 +709,267 @@ mod tests {
                 .collect();
             assert_eq!(count as usize, expected.len(), "count mismatch (n={n})");
             assert_eq!(visible, expected, "compaction order mismatch (n={n})");
+        }
+    }
+
+    /// Transform mapping the unit quad to the pixel-space rectangle
+    /// (x, y)-(x+w, y+h), same construction the widget layer uses.
+    fn rect(x: f32, y: f32, w: f32, h: f32) -> nalgebra::Matrix4<f32> {
+        nalgebra::Matrix4::new_translation(&nalgebra::Vector3::new(x, y, 0.0))
+            * nalgebra::Matrix4::new_nonuniform_scaling(&nalgebra::Vector3::new(w, h, 1.0))
+    }
+
+    fn instance(viewport_position: nalgebra::Matrix4<f32>, stencil_index: u32) -> InstanceData {
+        InstanceData {
+            viewport_position,
+            atlas_page: 0,
+            in_atlas_offset: [0.0, 0.0],
+            in_atlas_size: [1.0, 1.0],
+            stencil_index,
+            _padding1: 0,
+            _padding2: 0,
+        }
+    }
+
+    fn stencil(viewport_position: nalgebra::Matrix4<f32>) -> StencilData {
+        let (exists, inverse) = viewport_position
+            .try_inverse()
+            .map(|m| (1, m))
+            .unwrap_or((0, nalgebra::Matrix4::identity()));
+        StencilData {
+            viewport_position,
+            viewport_position_inverse_exists: exists,
+            viewport_position_inverse: inverse,
+            atlas_page: 0,
+            in_atlas_offset: [0.0, 0.0],
+            in_atlas_size: [1.0, 1.0],
+            _padding1: [0; 3],
+            _padding2: 0,
+            _padding3: [0; 2],
+        }
+    }
+
+    /// Run the visibility stage over real instance/stencil data and read the
+    /// visibility flags back.
+    fn run_visibility(
+        gpu: &TestGpu,
+        instances: &[InstanceData],
+        stencils: &[StencilData],
+        viewport: [f32; 2],
+    ) -> Vec<u32> {
+        let device = &gpu.device;
+        let n = instances.len();
+        let flags_bytes = (std::mem::size_of::<u32>() * n) as u64;
+
+        let make_storage = |label: &str, size: u64, extra: wgpu::BufferUsages| {
+            device.create_buffer(&wgpu::BufferDescriptor {
+                label: Some(label),
+                size,
+                usage: wgpu::BufferUsages::STORAGE | extra,
+                mapped_at_creation: false,
+            })
+        };
+
+        let instances_buffer = make_storage(
+            "vis test instances",
+            std::mem::size_of_val(instances) as u64,
+            wgpu::BufferUsages::COPY_DST,
+        );
+        let stencils_buffer = make_storage(
+            "vis test stencils",
+            (std::mem::size_of::<StencilData>() * stencils.len().max(1)) as u64,
+            wgpu::BufferUsages::COPY_DST,
+        );
+        let visible_instances = make_storage(
+            "vis test visible_instances",
+            flags_bytes,
+            wgpu::BufferUsages::empty(),
+        );
+        let counter = make_storage("vis test counter", 4, wgpu::BufferUsages::empty());
+        let draw_command = make_storage("vis test draw_command", 16, wgpu::BufferUsages::empty());
+        let flags_buffer = make_storage(
+            "vis test visibility_flags",
+            flags_bytes,
+            wgpu::BufferUsages::COPY_SRC | wgpu::BufferUsages::COPY_DST,
+        );
+        let offsets_buffer =
+            make_storage("vis test scan_offsets", flags_bytes, wgpu::BufferUsages::empty());
+
+        let data_bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("vis test data bind group"),
+            layout: &gpu.data_bind_group_layout,
+            entries: &[
+                wgpu::BindGroupEntry {
+                    binding: 0,
+                    resource: instances_buffer.as_entire_binding(),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 1,
+                    resource: stencils_buffer.as_entire_binding(),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 2,
+                    resource: visible_instances.as_entire_binding(),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 3,
+                    resource: counter.as_entire_binding(),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 4,
+                    resource: draw_command.as_entire_binding(),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 5,
+                    resource: flags_buffer.as_entire_binding(),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 6,
+                    resource: offsets_buffer.as_entire_binding(),
+                },
+            ],
+        });
+
+        gpu.queue
+            .write_buffer(&instances_buffer, 0, bytemuck::cast_slice(instances));
+        if !stencils.is_empty() {
+            gpu.queue
+                .write_buffer(&stencils_buffer, 0, bytemuck::cast_slice(stencils));
+        } else {
+            gpu.queue.write_buffer(
+                &stencils_buffer,
+                0,
+                bytemuck::bytes_of(&stencil(nalgebra::Matrix4::identity())),
+            );
+        }
+        // Poison the flags so stale values can't fake a pass in either direction.
+        gpu.queue
+            .write_buffer(&flags_buffer, 0, &vec![0xffu8; flags_bytes as usize]);
+
+        let readback = device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("vis test readback"),
+            size: flags_bytes,
+            usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::MAP_READ,
+            mapped_at_creation: false,
+        });
+
+        let stage = VisibilityStage::new(device, &gpu.data_bind_group_layout);
+        let mut encoder =
+            device.create_command_encoder(&wgpu::CommandEncoderDescriptor { label: None });
+        let params = StageParams {
+            normalize_matrix: make_normalize_matrix(viewport),
+            instance_count: n as u32,
+        };
+        stage.encode(&mut encoder, &data_bind_group, &params);
+        encoder.copy_buffer_to_buffer(&flags_buffer, 0, &readback, 0, flags_bytes);
+        gpu.queue.submit(std::iter::once(encoder.finish()));
+
+        readback
+            .slice(..)
+            .map_async(wgpu::MapMode::Read, |r| r.expect("buffer map"));
+        device
+            .poll(wgpu::PollType::wait_indefinitely())
+            .expect("device poll");
+        let flags: Vec<u32> = bytemuck::cast_slice(&readback.slice(..).get_mapped_range()).to_vec();
+        flags
+    }
+
+    /// SAT visibility test against hand-computed expectations on an 800x600
+    /// viewport, covering the false-negative classes of the previous
+    /// vertex-containment algorithm (identical glyph/stencil quads,
+    /// cross-shaped overlaps, boundary contact) alongside plain in/out cases.
+    #[test]
+    fn visibility_stage_culls_correctly() {
+        let Some(gpu) = test_gpu() else {
+            eprintln!("skipping: no real GPU adapter available");
+            return;
+        };
+        let viewport = [800.0, 600.0];
+
+        // Stencils (stencil_index on the instance is index + 1; 0 = none).
+        let stencils = vec![
+            stencil(rect(300.0, 300.0, 20.0, 20.0)), // 1: identical to the glyph quad below
+            stencil(rect(400.0, 400.0, 50.0, 50.0)), // 2: disjoint from its instance
+            stencil(rect(900.0, 100.0, 100.0, 50.0)), // 3: overlaps instance, but off-screen
+            stencil(rect(0.0, 0.0, 0.0, 0.0)),       // 4: zero scale -> non-invertible
+        ];
+        assert_eq!(
+            stencils[3].viewport_position_inverse_exists, 0,
+            "test setup: stencil 4 must be non-invertible"
+        );
+
+        let cases: Vec<(&str, InstanceData, u32)> = vec![
+            (
+                "plain quad inside the viewport",
+                instance(rect(100.0, 100.0, 200.0, 150.0), 0),
+                1,
+            ),
+            (
+                "fully off-screen to the right",
+                instance(rect(900.0, 100.0, 50.0, 50.0), 0),
+                0,
+            ),
+            (
+                "fully off-screen below",
+                instance(rect(100.0, 700.0, 50.0, 50.0), 0),
+                0,
+            ),
+            (
+                // Corners of the bar lie outside the viewport and viewport
+                // corners lie outside the bar: only edges cross. The previous
+                // vertex-containment test culled this.
+                "bar wider than the viewport (cross-shaped overlap)",
+                instance(rect(-100.0, 250.0, 1000.0, 100.0), 0),
+                1,
+            ),
+            (
+                // Every vertex sits exactly on the other quad's boundary.
+                "background exactly matching the viewport",
+                instance(rect(0.0, 0.0, 800.0, 600.0), 0),
+                1,
+            ),
+            (
+                // The glyph pattern: stencil quad bit-identical to the
+                // texture quad. The previous test culled every such glyph.
+                "glyph with stencil identical to its texture quad",
+                instance(rect(300.0, 300.0, 20.0, 20.0), 1),
+                1,
+            ),
+            (
+                "instance disjoint from its stencil",
+                instance(rect(100.0, 100.0, 50.0, 50.0), 2),
+                0,
+            ),
+            (
+                // Instance spans the right viewport edge; the part of it the
+                // stencil lets through is entirely off-screen.
+                "stencil off-screen (masked pixels never visible)",
+                instance(rect(700.0, 100.0, 400.0, 50.0), 3),
+                0,
+            ),
+            (
+                // Render draws unmasked when the stencil transform is not
+                // invertible; culling must mirror that and keep the instance.
+                "non-invertible stencil falls back to unmasked",
+                instance(rect(100.0, 100.0, 50.0, 50.0), 4),
+                1,
+            ),
+            (
+                // Shares only the x = 800 edge with the viewport:
+                // boundary-inclusive SAT keeps it (conservative).
+                "touching the viewport edge only",
+                instance(rect(800.0, 100.0, 50.0, 50.0), 0),
+                1,
+            ),
+        ];
+
+        let instances: Vec<InstanceData> = cases.iter().map(|(_, i, _)| *i).collect();
+        let flags = run_visibility(&gpu, &instances, &stencils, viewport);
+        for (i, (label, _, expected)) in cases.iter().enumerate() {
+            assert_eq!(
+                flags[i], *expected,
+                "visibility mismatch for case {i}: {label}"
+            );
         }
     }
 }


### PR DESCRIPTION
## Note

This PR was generated by Fable 5.

## Summary

Refactored the monolithic culling/compaction pipeline into a modular system of swappable compute stages. This enables algorithm experimentation (e.g., different prefix-sum implementations) without changing core renderer code, and fixes an intermittent draw-order bug caused by non-order-preserving compaction.

## Key Changes

- **New `stages.rs` module**: Defines the `ComputeStage` trait and four pipeline stages:
  - `VisibilityStage`: Per-instance visibility test (writes 0/1 flags)
  - `SingleThreadPrefixSumStage`: Naive reference prefix-sum implementation
  - `BlellochPrefixSumStage`: Default two-level work-efficient scan with fallback
  - `ScatterStage`: Order-preserving compaction using prefix-sum offsets
  - `CommandStage`: Converts visible count to indirect draw arguments

- **Order-preserving compaction**: Replaced the buggy `atomicAdd` pattern with an exclusive prefix-sum + scatter approach that guarantees submission order is preserved, fixing intermittent draw-order corruption

- **Modular bind group layout**: Extracted `create_data_bind_group_layout()` as a public function so stages can construct compatible pipelines independently

- **Shader reorganization**:
  - `renderer_cull.wgsl`: Updated to write visibility flags instead of directly compacting; improved viewport/stencil overlap tests
  - `renderer_prefix_sum_single_thread.wgsl`: New reference implementation (sequential scan)
  - `renderer_prefix_sum_blelloch.wgsl`: New default implementation (two-level Blelloch scan, three dispatches)
  - `renderer_scatter.wgsl`: New stage that scatters visible indices using prefix-sum offsets
  - `renderer_command.wgsl`: Extracted from inline code

- **Comprehensive GPU tests**: Added correctness tests comparing prefix-sum implementations against CPU exclusive scan and verifying end-to-end compaction order preservation

## Implementation Details

- Stages communicate only through the shared data bind group, enabling transparent algorithm swaps
- `BlellochPrefixSumStage` owns a private `block_sums` scratch buffer and bind group, keeping the shared layout algorithm-agnostic
- Capacity limits (512 blocks × 512 elements = 262K instances) with automatic fallback to single-thread scan
- Tests skip gracefully when no real GPU adapter is available